### PR TITLE
Fix: 사물함 컴포넌트 위치 수정#14

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,8 @@
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import "./App.css";
-import MainPage from "./pages/MainPage";
-import LoginPage from "./pages/Login/LoginPage";
-import ErrorPage from "./pages/ErrorPage";
+import MainPage from "@/pages/MainPage";
+import LoginPage from "@/pages/Login/LoginPage";
+import ErrorPage from "@/pages/ErrorPage";
 
 function App() {
   return (

--- a/src/components/Cabinet/CabinetButtonComponent.tsx
+++ b/src/components/Cabinet/CabinetButtonComponent.tsx
@@ -45,8 +45,8 @@ const CabinetButtonComponent = ({
   };
 
   return (
-    <div className="absolute p-24 flex justify-center items-center w-full">
-      {cabinetButtons()}
+    <div className="absolute py-24 px-6 flex justify-center w-full">
+      <div className="flex flex-wrap">{cabinetButtons()}</div>
     </div>
   );
 };

--- a/src/components/Cabinet/CabinetStatusInformation.tsx
+++ b/src/components/Cabinet/CabinetStatusInformation.tsx
@@ -12,9 +12,9 @@ const CabinetStatusInformation = () => {
   return (
     <div className="flex flex-row absolute bottom-5 left-5">
       {cabinetStatus.map((status, index) => (
-        <div key={index} className="px-2 flex flex-row">
-          <div className={`w-4 h-4 ${status.color} mr-2 rounded-sm font-`} />
-          {status.label}
+        <div key={index} className="px-2 flex whitespace-nowrap">
+          <div className={`w-4 h-4 ${status.color} mr-2 rounded-sm`} />
+          <div>{status.label}</div>
         </div>
       ))}
     </div>

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -26,7 +26,7 @@ const MainPage = () => {
 
   return (
     <div>
-      {/* 상단 네비게이션바 */}
+      {/* 상단 네비게이션바(화면 크기 상관없이 표시) */}
       <SideNavigationLayout
         buildings={buildings}
         selectedBuilding={selectedBuilding}
@@ -36,46 +36,10 @@ const MainPage = () => {
         setIsOpen={setIsOpen}
       />
 
-      {/* 건물 정보(좌측) */}
-      <div className="absolute inset-y-0 left-0 w-40 border-r-2 border-gray-400 flex-col pt-20 hidden md:flex">
-        <BuildingSelectButton
-          buildings={buildings}
-          selectedBuilding={selectedBuilding}
-          setSelectedBuilding={setSelectedBuilding}
-          selectedFloor={selectedFloor}
-          setSelectedFloor={setSelectedFloor}
-        />
-
-        {/* 하단 메뉴(좌측) */}
-        <CabinetFooterMenuButton />
-      </div>
-
-      {/* 사물함 위치(중앙) */}
-      <div className="absolute inset-y-0 left-0 right-0 md:left-64 md:right-80 border-gray-400 pt-20 flex">
-        {/* 건물 선택 후, 층수 선택을 둘 다 해야 사물함 컴포넌트가 보임 */}
-        {selectedBuilding !== null && selectedFloor !== null && (
-          <>
-            <CabinetButtonComponent
-              rows={4}
-              columns={12}
-              selectedBuilding={buildings[selectedBuilding]}
-              selectedFloor={buildings[selectedBuilding]?.floors[selectedFloor]}
-              setSelectedCabinet={setSelectedCabinet}
-            />
-            <CabinetStatusInformation />
-          </>
-        )}
-      </div>
-
-      {/* 선택한 사물함 정보(우측) */}
-      <div className="absolute inset-y-0 right-0 w-80 border-gray-400 border-l-2 pt-20 hidden md:flex">
-        <SelectedCabinetInformation selectedCabinet={selectedCabinet} />
-      </div>
-
-      {/* 아래는 화면 축소(md)일 때의 코드 */}
-      {/* 건물 & 층 선택 안했을 때는 건물 & 층 선택하는 컴포넌트만 표시 */}
-      {selectedFloor === null && (
-        <div className="absolute inset-y-0 left-0 w-40 border-r-2 border-gray-400 flex-col pt-20 flex md:hidden">
+      {/* 화면 크기 = 768px 이상일 때 */}
+      <div className="md:flex">
+        {/* 건물 정보(좌측) */}
+        <div className="absolute inset-y-0 left-0 w-40 border-r-2 border-gray-400 flex-col pt-20 hidden md:flex">
           <BuildingSelectButton
             buildings={buildings}
             selectedBuilding={selectedBuilding}
@@ -83,16 +47,86 @@ const MainPage = () => {
             selectedFloor={selectedFloor}
             setSelectedFloor={setSelectedFloor}
           />
+
           {/* 하단 메뉴(좌측) */}
           <CabinetFooterMenuButton />
         </div>
-      )}
-      {/* 사물함 선택 -> cabinetRental 컴포넌트 표시 */}
-      {selectedCabinet && (
-        <div className="absolute inset-y-0 right-0 w-80 border-gray-400 border-l-2 pt-20 flex md:hidden">
+
+        {/* 사물함 위치(중앙) */}
+        <div className="absolute inset-y-0 left-0 right-0 md:left-64 md:right-80 border-gray-400 pt-16 hidden md:flex">
+          {/* 건물 선택 후, 층수 선택을 둘 다 해야 사물함 컴포넌트가 보임 */}
+          {selectedBuilding !== null && selectedFloor !== null && (
+            <>
+              <CabinetButtonComponent
+                rows={4}
+                columns={12}
+                selectedBuilding={buildings[selectedBuilding]}
+                selectedFloor={
+                  buildings[selectedBuilding]?.floors[selectedFloor]
+                }
+                setSelectedCabinet={setSelectedCabinet}
+              />
+              <CabinetStatusInformation />
+            </>
+          )}
+        </div>
+        {/* 선택한 사물함 정보(우측) */}
+        <div className="absolute inset-y-0 right-0 w-80 border-gray-400 border-l-2 pt-20 hidden md:flex">
           <SelectedCabinetInformation selectedCabinet={selectedCabinet} />
         </div>
-      )}
+      </div>
+
+      {/* 화면 크기 = 768px 이하일 때 */}
+      <div className="md:hidden">
+        {/* 건물 & 층 선택 안했을 때 -> 건물 & 층 선택하는 컴포넌트만 표시 */}
+        {selectedFloor === null && (
+          <div className="absolute inset-y-0 left-0 w-40 border-r-2 border-gray-400 flex-col pt-20 flex">
+            <BuildingSelectButton
+              buildings={buildings}
+              selectedBuilding={selectedBuilding}
+              setSelectedBuilding={setSelectedBuilding}
+              selectedFloor={selectedFloor}
+              setSelectedFloor={setSelectedFloor}
+            />
+            {/* 하단 메뉴(좌측) */}
+            <CabinetFooterMenuButton />
+          </div>
+        )}
+
+        {/* 건물&층 선택 완료 -> 사물함 컴포넌트 표시 */}
+        {selectedBuilding !== null && selectedFloor !== null && (
+          <div
+            className={`absolute inset-y-0 left-0 right-0 border-gray-400 pt-16 flex ${
+              selectedCabinet ? "w-8/12" : "w-full"
+            }`}
+          >
+            <>
+              <div className="absolute inset-y-0 left-12 right-8 pt-16">
+                <CabinetButtonComponent
+                  rows={4}
+                  columns={12}
+                  selectedBuilding={buildings[selectedBuilding]}
+                  selectedFloor={
+                    buildings[selectedBuilding]?.floors[selectedFloor]
+                  }
+                  setSelectedCabinet={setSelectedCabinet}
+                />
+              </div>
+              {/* 화면 크기 = 768px 이하일 때 사물함 정보 숨김 */}
+              <div className="hidden sl:flex">
+                <CabinetStatusInformation />
+              </div>
+            </>
+          </div>
+        )}
+
+        {/* 사물함 선택 완료 -> cabinetRental 컴포넌트 표시 */}
+        {selectedCabinet && (
+          <div className="absolute inset-y-0 right-0 w-80 border-gray-400 border-l-2 pt-20 flex">
+            <SelectedCabinetInformation selectedCabinet={selectedCabinet} />
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -36,8 +36,8 @@ const MainPage = () => {
         setIsOpen={setIsOpen}
       />
 
-      <div className="absolute inset-y-0 left-0 w-40 border-r-2 border-gray-400 flex flex-col pt-20">
-        {/* 건물 정보(좌측) */}
+      {/* 건물 정보(좌측) */}
+      <div className="absolute inset-y-0 left-0 w-40 border-r-2 border-gray-400 flex-col pt-20 hidden md:flex">
         <BuildingSelectButton
           buildings={buildings}
           selectedBuilding={selectedBuilding}
@@ -45,27 +45,54 @@ const MainPage = () => {
           selectedFloor={selectedFloor}
           setSelectedFloor={setSelectedFloor}
         />
+
         {/* 하단 메뉴(좌측) */}
         <CabinetFooterMenuButton />
       </div>
 
       {/* 사물함 위치(중앙) */}
-      <div className="absolute inset-y-0 left-64 right-80 border-r-2 border-gray-400 pt-20 hidden sl:block flex-col">
+      <div className="absolute inset-y-0 left-0 right-0 md:left-64 md:right-80 border-gray-400 pt-20 flex">
         {/* 건물 선택 후, 층수 선택을 둘 다 해야 사물함 컴포넌트가 보임 */}
         {selectedBuilding !== null && selectedFloor !== null && (
-          <CabinetButtonComponent
-            rows={4}
-            columns={12}
-            selectedBuilding={buildings[selectedBuilding]}
-            selectedFloor={buildings[selectedBuilding]?.floors[selectedFloor]}
-            setSelectedCabinet={setSelectedCabinet}
-          />
+          <>
+            <CabinetButtonComponent
+              rows={4}
+              columns={12}
+              selectedBuilding={buildings[selectedBuilding]}
+              selectedFloor={buildings[selectedBuilding]?.floors[selectedFloor]}
+              setSelectedCabinet={setSelectedCabinet}
+            />
+            <CabinetStatusInformation />
+          </>
         )}
-        <CabinetStatusInformation />
       </div>
 
-      {/* 선택한 사물함 정보(우측) -> 추후 사물함 컴포넌트와 연결 */}
-      <SelectedCabinetInformation selectedCabinet={selectedCabinet} />
+      {/* 선택한 사물함 정보(우측) */}
+      <div className="absolute inset-y-0 right-0 w-80 border-gray-400 border-l-2 pt-20 hidden md:flex">
+        <SelectedCabinetInformation selectedCabinet={selectedCabinet} />
+      </div>
+
+      {/* 아래는 화면 축소(md)일 때의 코드 */}
+      {/* 건물 & 층 선택 안했을 때는 건물 & 층 선택하는 컴포넌트만 표시 */}
+      {selectedFloor === null && (
+        <div className="absolute inset-y-0 left-0 w-40 border-r-2 border-gray-400 flex-col pt-20 flex md:hidden">
+          <BuildingSelectButton
+            buildings={buildings}
+            selectedBuilding={selectedBuilding}
+            setSelectedBuilding={setSelectedBuilding}
+            selectedFloor={selectedFloor}
+            setSelectedFloor={setSelectedFloor}
+          />
+          {/* 하단 메뉴(좌측) */}
+          <CabinetFooterMenuButton />
+        </div>
+      )}
+      {/* 사물함 선택 -> cabinetRental 컴포넌트 표시 */}
+      {selectedCabinet && (
+        <div className="absolute inset-y-0 right-0 w-80 border-gray-400 border-l-2 pt-20 flex md:hidden">
+          <SelectedCabinetInformation selectedCabinet={selectedCabinet} />
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

> fix: 사물함 컴포넌트 위치 수정#14

## 📝작업 내용

> - 화면 크기가 줄어들 때
>    - 사물함 컴포넌트 위치 조정
>    - 건물 & 층 선택 전에는 건물 & 층을 선택할 수 있는 컴포넌트만 표시 
>    - 건물 & 층 선택 후에는 사물함 컴포넌트만 표시

### 스크린샷 (선택)
<img width="1001" alt="스크린샷 2024-10-22 오후 8 26 41" src="https://github.com/user-attachments/assets/3cdb6ab4-df09-4cab-bf1d-08d37c46fa9c">

- 건물 & 층 선택 전
<img width="862" alt="스크린샷 2024-10-22 오후 8 54 06" src="https://github.com/user-attachments/assets/f98a3fc5-d8f6-49f8-866d-c6e9ba2e754b">

- 건물 & 층 선택 후
<img width="861" alt="스크린샷 2024-10-22 오후 8 54 15" src="https://github.com/user-attachments/assets/b855e17a-cef2-4da7-91ea-a884ee2e72de">


## 💬리뷰 요구사항(선택)
> - 현재 아래와 같은 오류가 발생하는데, 어디를 수정해야 할 지 도저히 안 떠올라서 추후에 수정하겠습니당
<img width="848" alt="image" src="https://github.com/user-attachments/assets/dd6450dd-32d6-4243-b3b0-9eb1ed6c56a1">

#### 💡 수정 완료 💡
<img width="785" alt="image" src="https://github.com/user-attachments/assets/eac211c6-f139-4478-a2fe-4ed35ec59f2b">
