### PR TITLE
Feat: Main Page 사물함 API 요청

### DIFF
--- a/src/api/cabinetCallApi.tsx
+++ b/src/api/cabinetCallApi.tsx
@@ -2,7 +2,7 @@ import axios from "axios";
 const CABINET_URL = import.meta.env.VITE_CABINET_URL;
 
 // 메인 페이지: 건물, 층 선택 시 호출되는 API
-export const cabinetCallApi = async (building: string, floor: string) => {
+export const cabinetCallApi = async (building: string, floor: number) => {
   try {
     const response = await axios.get(
       `${CABINET_URL}?building=${building}&floor=${floor}`

--- a/src/api/searchKeywordApi.tsx
+++ b/src/api/searchKeywordApi.tsx
@@ -7,8 +7,8 @@ export const searchKeywordApi = async (keyword) => {
     const response = await axios.get(`${SEARCH_URL}/detail?keyword=${keyword}`);
 
     const filterData = response.data.filter((inputValue) => {
-      // return inputValue.cabinetNumber.toString().includes(keyword);
-      return inputValue.building.toString().includes(keyword);
+      return inputValue.cabinetNumber.toString().includes(keyword);
+      // return inputValue.building.toString().includes(keyword); // css 보기 위한 용도 -> 추후 삭제
     });
     return filterData;
   } catch (error) {

--- a/src/components/BuildingSelectButton.tsx
+++ b/src/components/BuildingSelectButton.tsx
@@ -21,7 +21,7 @@ const BuildingSelectButton = ({
   const { setSearchParams } = useSearch();
 
   // 건물, 층에 대한 api
-  const handlecabinetCall = async (building, floor) => {
+  const handlecabinetCall = async (building: string, floor: number) => {
     try {
       const response = await cabinetCallApi(building, floor);
       setSearchParams({ building, floor: floor.toString() }); // 쿼리스트링
@@ -52,16 +52,16 @@ const BuildingSelectButton = ({
 
             {selectedBuilding === building.name && (
               <div className="absolute inset-y-0 left-40 w-24 border-r-2 border-gray-400 flex flex-col pt-20">
-                {building.floors.map((floor, floorIndex) => (
+                {building.floors.map((floor) => (
                   <button
-                    key={floorIndex}
+                    key={floor}
                     className={`p-4 w-auto text-gray-500 hover:bg-blue-600 hover:text-white mx-2 rounded-lg transition-all duration-150 ${
-                      selectedFloor === floorIndex
+                      selectedFloor === floor
                         ? "bg-blue-600 text-white mx-2"
                         : ""
                     }`}
                     onClick={() => {
-                      setSelectedFloor(floorIndex); // 선택된 층을 업데이트
+                      setSelectedFloor(floor); // 선택된 층을 업데이트
                       handlecabinetCall(building.name, floor);
                     }}
                   >

--- a/src/components/BuildingSelectButton.tsx
+++ b/src/components/BuildingSelectButton.tsx
@@ -9,6 +9,7 @@ interface BuildingSelectButtonProps {
   setSelectedBuilding: (building: string | null) => void;
   selectedFloor: number | null;
   setSelectedFloor: (floor: number | null) => void;
+  setSelectedCabinet: (cabinet: number | null) => void;
 }
 
 const BuildingSelectButton = ({
@@ -17,6 +18,7 @@ const BuildingSelectButton = ({
   setSelectedBuilding,
   selectedFloor,
   setSelectedFloor,
+  setSelectedCabinet,
 }: BuildingSelectButtonProps) => {
   const { setSearchParams } = useSearch();
 
@@ -44,7 +46,8 @@ const BuildingSelectButton = ({
               }`}
               onClick={() => {
                 setSelectedBuilding(building.name);
-                setSelectedFloor(null);
+                setSelectedFloor(null); // 층 선택 초기화
+                setSelectedCabinet(null); // 사물함 선택 초기화
               }}
             >
               {building.name}

--- a/src/components/Cabinet/CabinetButtonComponent.tsx
+++ b/src/components/Cabinet/CabinetButtonComponent.tsx
@@ -1,18 +1,11 @@
 // 사물함 버튼 컴포넌트 배열 관련
-import { cabinetCallApi } from "@/api/cabinetCallApi";
 
-import { useState, useEffect } from "react";
+import { useCabinetData } from "@/hooks/useCabinetData";
 
 interface CabinetButtonComponentProps {
   selectedBuilding: { name: string } | null;
   selectedFloor: number | null;
   setSelectedCabinet: (cabinetNumber: number) => void;
-}
-interface cabinetApiData {
-  cabinetNumber: number;
-  xPos: number;
-  yPos: number;
-  status: string;
 }
 
 const CabinetButtonComponent = ({
@@ -20,23 +13,7 @@ const CabinetButtonComponent = ({
   selectedFloor,
   setSelectedCabinet,
 }: CabinetButtonComponentProps) => {
-  const [cabinetData, setCabinetData] = useState<cabinetApiData[]>([]);
-
-  const handleCabinetCall = async (building: string, floor: number) => {
-    try {
-      const response = await cabinetCallApi(building, floor);
-      setCabinetData(response.cabinets);
-    } catch (error) {
-      console.log(error);
-    }
-  };
-
-  // building, floor 값이 변경될 때마다 API 호출
-  useEffect(() => {
-    if (selectedBuilding !== null && selectedFloor !== null) {
-      handleCabinetCall(selectedBuilding.name, selectedFloor);
-    }
-  }, [selectedBuilding, selectedFloor]);
+  const cabinetData = useCabinetData(selectedBuilding, selectedFloor);
 
   // 각 상태에 대한 버튼 색상 설정
   const getStatusColor = (status: string) => {

--- a/src/components/Cabinet/CabinetButtonComponent.tsx
+++ b/src/components/Cabinet/CabinetButtonComponent.tsx
@@ -25,7 +25,6 @@ const CabinetButtonComponent = ({
   const handleCabinetCall = async (building: string, floor: number) => {
     try {
       const response = await cabinetCallApi(building, floor);
-      // setCabinetData(response?.cabinets || []); // 응답 데이터에서 사물함 목록 업데이트
       setCabinetData(response.cabinets);
     } catch (error) {
       console.log(error);
@@ -39,15 +38,41 @@ const CabinetButtonComponent = ({
     }
   }, [selectedBuilding, selectedFloor]);
 
+  // 각 상태에 대한 버튼 색상 설정
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case "MINE":
+        return "bg-lime-500"; // 내 사물함
+      case "USING":
+        return "bg-purple-500"; // 사용 중
+      case "OVERDUE":
+        return "bg-red-500"; // 반납 지연
+      case "AVAILABLE":
+        return "bg-gray-300"; // 이용 가능
+      case "BROKEN":
+        return "bg-gray-700"; // 사용 불가
+    }
+  };
+
+  // 각 상태에 따른 텍스트 색상 설정
+  const getStatusTextColor = (status: string) => {
+    if (status === "AVAILABLE" || status === "MINE") {
+      return "text-black"; // AVAILABLE, MINE일 경우 text-black
+    }
+    return "text-white"; // 나머지 상태는 text-white
+  };
+
   return (
     <div className="w-full">
       <div className="relative top-14 left-1/3 w-[30rem] h-5/6 flex items-center justify-center overflow-scroll">
         {cabinetData.map((cabinet) => (
           <button
-            key={cabinet.cabinetNumber} // 데이터의 cabinetNumber를 키로 사용
-            className="absolute w-16 h-20 rounded-md bg-gray-300 text-gray-500 text-sm hover:bg-gray-200 flex items-end p-2"
+            key={cabinet.cabinetNumber}
+            className={`absolute w-16 h-20 rounded-md hover:bg-opacity-80 flex items-end text-sm p-2 ${getStatusColor(
+              cabinet.status
+            )} ${getStatusTextColor(cabinet.status)}`}
             style={{
-              top: `${1000 - cabinet.yPos}px`, // // API에서 받은 yPos 사용 -> yPos 값을 반전 (yPos 값이 작은 cabinet이 위로 배치됨)
+              top: `${1000 - cabinet.yPos}px`, // API에서 받은 yPos 사용
               left: `${cabinet.xPos}px`, // API에서 받은 xPos 사용
             }}
             onClick={() => setSelectedCabinet(cabinet.cabinetNumber)}

--- a/src/components/Cabinet/CabinetStatusInformation.tsx
+++ b/src/components/Cabinet/CabinetStatusInformation.tsx
@@ -2,11 +2,11 @@
 
 const CabinetStatusInformation = () => {
   const cabinetStatus = [
-    { color: "bg-lime-500", label: "내 사물함" },
-    { color: "bg-purple-500", label: "사용 중" },
-    { color: "bg-red-500", label: "반납 지연" },
-    { color: "bg-gray-300", label: "이용 가능" },
-    { color: "bg-gray-700", label: "사용 불가" },
+    { id: "MINE", color: "bg-lime-500", label: "내 사물함" },
+    { id: "USING", color: "bg-purple-500", label: "사용 중" },
+    { id: "OVERDUE", color: "bg-red-500", label: "반납 지연" },
+    { id: "AVAILABLE", color: "bg-gray-300", label: "이용 가능" },
+    { id: "BROKEN", color: "bg-gray-700", label: "사용 불가" },
   ];
 
   return (

--- a/src/components/Cabinet/SelectedCabinetInformation.tsx
+++ b/src/components/Cabinet/SelectedCabinetInformation.tsx
@@ -3,16 +3,24 @@ import CabinetSVG from "@/icons/cabinet.svg?react";
 
 // 선택된 사물함 정보
 interface SelectedCabinetInformationProps {
+  selectedBuilding: string | null;
+  selectedFloor: number | null;
   selectedCabinet: number | null;
 }
 
 const SelectedCabinetInformation = ({
+  selectedBuilding,
+  selectedFloor,
   selectedCabinet,
 }: SelectedCabinetInformationProps) => {
   return (
     <div className="absolute inset-y-0 right-0 w-80 pt-20 flex flex-col justify-center items-center">
       {selectedCabinet ? (
-        <CabinetRental selectedCabinet={selectedCabinet} />
+        <CabinetRental
+          selectedBuilding={selectedBuilding}
+          selectedFloor={selectedFloor}
+          selectedCabinet={selectedCabinet}
+        />
       ) : (
         <div>
           <div className="flex justify-center pb-5">

--- a/src/components/Cabinet/SelectedCabinetInformation.tsx
+++ b/src/components/Cabinet/SelectedCabinetInformation.tsx
@@ -15,7 +15,8 @@ const SelectedCabinetInformation = ({
 }: SelectedCabinetInformationProps) => {
   return (
     <div className="absolute inset-y-0 right-0 w-80 pt-20 flex flex-col justify-center items-center">
-      {selectedCabinet ? (
+      {/* 건물, 층, 사물함 모두 선택했을 때만 사물함 정보 표시 */}
+      {selectedCabinet !== null ? (
         <CabinetRental
           selectedBuilding={selectedBuilding}
           selectedFloor={selectedFloor}

--- a/src/components/CabinetFooterMenuButton.tsx
+++ b/src/components/CabinetFooterMenuButton.tsx
@@ -3,7 +3,6 @@
 import LogSVG from "@/icons/log.svg?react";
 import LogoutSVG from "@/icons/logout.svg?react";
 import CabinetSVG from "@/icons/cabinet.svg?react";
-import { useNavigate, useLocation } from "react-router";
 import { useLogout } from "@/hooks/useLogout";
 
 const CabinetFooterMenuButton = () => {

--- a/src/components/CabinetState/CabinetRental.tsx
+++ b/src/components/CabinetState/CabinetRental.tsx
@@ -7,10 +7,16 @@ import CabinetRentalComplete from "@/components/CabinetState/CabinetRentalComple
 import CabinetSVG from "@/icons/cabinet.svg?react";
 
 interface CabinetRentalProps {
+  selectedBuilding: string | null;
+  selectedFloor: number | null;
   selectedCabinet: number;
 }
 
-const CabinetRental = ({ selectedCabinet }: CabinetRentalProps) => {
+const CabinetRental = ({
+  selectedBuilding,
+  selectedFloor,
+  selectedCabinet,
+}: CabinetRentalProps) => {
   const { openRentalModal, setOpenRentalModal } = useCabinetRentalModal();
   const { isRented, setIsRented } = useCabinetStateManagement();
 
@@ -30,7 +36,13 @@ const CabinetRental = ({ selectedCabinet }: CabinetRentalProps) => {
 
   // 사물함이 대여 중이라면 CabinetRentalComplete.tsx 반환
   if (isRented) {
-    return <CabinetRentalComplete selectedCabinet={selectedCabinet} />;
+    return (
+      <CabinetRentalComplete
+        selectedBuilding={selectedBuilding}
+        selectedFloor={selectedFloor}
+        selectedCabinet={selectedCabinet}
+      />
+    );
   }
 
   return (
@@ -38,7 +50,9 @@ const CabinetRental = ({ selectedCabinet }: CabinetRentalProps) => {
       <div className="pb-5 flex justify-center">
         <CabinetSVG />
       </div>
-      <div className="font-bold text-xl">{selectedCabinet}번</div>
+      <div className="font-bold text-xl">
+        {selectedBuilding} {selectedFloor} {selectedCabinet}번
+      </div>
       <button
         onClick={clickedRentalButton}
         className="mt-10 p-4 w-60 bg-blue-600 text-white border border-blue-600 rounded-lg hover:bg-blue-500 hover:text-white transition-all duration-150"
@@ -53,6 +67,8 @@ const CabinetRental = ({ selectedCabinet }: CabinetRentalProps) => {
         <CabinetRentalConfirmModal
           closeRentalModal={closeRentalModal}
           confirmRental={confirmRental}
+          selectedBuilding={selectedBuilding}
+          selectedFloor={selectedFloor}
           selectedCabinet={selectedCabinet}
         />
       )}

--- a/src/components/CabinetState/CabinetRentalComplete.tsx
+++ b/src/components/CabinetState/CabinetRentalComplete.tsx
@@ -4,12 +4,17 @@ import { useCabinetReturnModal } from "@/hooks/useCabinetReturnModal";
 import { useCabinetStateManagement } from "@/hooks/useCabinetStateManagement";
 import CabinetReturnConfirmModal from "@/components/CabinetState/CabinetReturnConfirmModal";
 import CabinetRental from "@/components/CabinetState/CabinetRental";
+import CabinetSVG from "@/icons/cabinet.svg?react";
 
 interface CabinetRentalCompleteProps {
+  selectedBuilding: string | null;
+  selectedFloor: number | null;
   selectedCabinet: number;
 }
 
 const CabinetRentalComplete = ({
+  selectedBuilding,
+  selectedFloor,
   selectedCabinet,
 }: CabinetRentalCompleteProps) => {
   const { openReturnModal, setOpenReturnModal } = useCabinetReturnModal();
@@ -32,12 +37,23 @@ const CabinetRentalComplete = ({
   };
 
   if (isRented) {
-    return <CabinetRental selectedCabinet={selectedCabinet} />;
+    return (
+      <CabinetRental
+        selectedBuilding={selectedBuilding}
+        selectedFloor={selectedFloor}
+        selectedCabinet={selectedCabinet}
+      />
+    );
   }
 
   return (
     <div>
-      <h2 className="font-bold text-xl">{selectedCabinet}번 사물함</h2>
+      <div className="pb-5 flex justify-center">
+        <CabinetSVG />
+      </div>
+      <h2 className="font-bold text-xl">
+        {selectedBuilding} {selectedFloor} {selectedCabinet}번
+      </h2>
       <div className="p-10">
         <button
           onClick={clickedReturnButton}

--- a/src/components/CabinetState/CabinetRentalConfirmModal.tsx
+++ b/src/components/CabinetState/CabinetRentalConfirmModal.tsx
@@ -1,12 +1,16 @@
 // 대여 버튼 눌렀을 때, 대여 확인 모달
 
 interface CabinetRentalConfirmModalProps {
+  selectedBuilding: string | null;
+  selectedFloor: number | null;
   selectedCabinet: number;
   closeRentalModal: () => void; // 모달 닫기 함수
   confirmRental: () => void; // 대여 확인 버튼
 }
 
 const CabinetRentalConfirmModal = ({
+  selectedBuilding,
+  selectedFloor,
   selectedCabinet,
   closeRentalModal,
   confirmRental,
@@ -20,7 +24,9 @@ const CabinetRentalConfirmModal = ({
           <p>
             대여 기간은 <strong>2024/12/31 23:59</strong>까지 입니다.
           </p>
-          <b>{selectedCabinet}번 사물함</b>
+          <b>
+            {selectedBuilding} {selectedFloor} {selectedCabinet}번 사물함
+          </b>
           <p>이 사물함을 대여하시겠습니까?</p>
         </div>
 

--- a/src/hooks/useCabinetData.tsx
+++ b/src/hooks/useCabinetData.tsx
@@ -1,0 +1,35 @@
+// 사물함 API에서 data 불러오기 위한 hook
+
+import { useState, useEffect } from "react";
+import { cabinetCallApi } from "@/api/cabinetCallApi";
+
+interface cabinetApiData {
+  cabinetNumber: number;
+  xPos: number;
+  yPos: number;
+  status: string;
+}
+
+export const useCabinetData = (
+  selectedBuilding: { name: string } | null,
+  selectedFloor: number | null
+) => {
+  const [cabinetData, setCabinetData] = useState<cabinetApiData[]>([]);
+
+  useEffect(() => {
+    const handleCabinetCall = async (building: string, floor: number) => {
+      try {
+        const response = await cabinetCallApi(building, floor);
+        setCabinetData(response.cabinets);
+      } catch (error) {
+        console.log(error);
+      }
+    };
+
+    if (selectedBuilding !== null && selectedFloor !== null) {
+      handleCabinetCall(selectedBuilding.name, selectedFloor);
+    }
+  }, [selectedBuilding, selectedFloor]);
+
+  return cabinetData;
+};

--- a/src/hooks/useSearchResultButton.tsx
+++ b/src/hooks/useSearchResultButton.tsx
@@ -6,7 +6,7 @@ import { cabinetCallApi } from "@/api/cabinetCallApi";
 export const useSearchResultButton = () => {
   const navigate = useNavigate();
 
-  const handleClickResultButton = async (building, floor) => {
+  const handleClickResultButton = async (building: string, floor: number) => {
     try {
       const response = await cabinetCallApi(building, floor);
       navigate(`/main?building=${building}&floor=${floor}`); // 선택한 사물함 페이지로 이동

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -29,6 +29,7 @@ const MainPage = () => {
         selectedBuilding={selectedBuilding}
         setSelectedBuilding={setSelectedBuilding}
         setSelectedFloor={setSelectedFloor}
+        setSelectedCabinet={setSelectedCabinet} // 추가
       />
 
       {/* 화면 크기 = 768px 이상일 때 */}
@@ -41,6 +42,7 @@ const MainPage = () => {
             setSelectedBuilding={setSelectedBuilding}
             selectedFloor={selectedFloor}
             setSelectedFloor={setSelectedFloor}
+            setSelectedCabinet={setSelectedCabinet}
           />
 
           {/* 하단 메뉴(좌측) */}
@@ -86,6 +88,7 @@ const MainPage = () => {
               setSelectedBuilding={setSelectedBuilding}
               selectedFloor={selectedFloor}
               setSelectedFloor={setSelectedFloor}
+              setSelectedCabinet={setSelectedCabinet}
             />
             {/* 하단 메뉴(좌측) */}
             <CabinetFooterMenuButton />

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -53,12 +53,12 @@ const MainPage = () => {
           {selectedBuilding !== null && selectedFloor !== null && (
             <>
               <CabinetButtonComponent
-                rows={4}
-                columns={12}
-                selectedBuilding={buildings[selectedBuilding]}
-                selectedFloor={
-                  buildings[selectedBuilding]?.floors[selectedFloor]
+                selectedBuilding={
+                  buildings.find(
+                    (building) => building.name === selectedBuilding
+                  ) || null
                 }
+                selectedFloor={selectedFloor}
                 setSelectedCabinet={setSelectedCabinet}
               />
               <CabinetStatusInformation />
@@ -67,7 +67,11 @@ const MainPage = () => {
         </div>
         {/* 선택한 사물함 정보(우측) */}
         <div className="absolute inset-y-0 right-0 w-80 border-gray-400 border-l-2 pt-20 hidden md:flex">
-          <SelectedCabinetInformation selectedCabinet={selectedCabinet} />
+          <SelectedCabinetInformation
+            selectedBuilding={selectedBuilding}
+            selectedFloor={selectedFloor}
+            selectedCabinet={selectedCabinet}
+          />
         </div>
       </div>
 
@@ -98,12 +102,12 @@ const MainPage = () => {
             <>
               <div className="absolute inset-y-0 left-12 right-8 pt-16">
                 <CabinetButtonComponent
-                  rows={4}
-                  columns={12}
-                  selectedBuilding={buildings[selectedBuilding]}
-                  selectedFloor={
-                    buildings[selectedBuilding]?.floors[selectedFloor]
+                  selectedBuilding={
+                    buildings.find(
+                      (building) => building.name === selectedBuilding
+                    ) || null
                   }
+                  selectedFloor={selectedFloor}
                   setSelectedCabinet={setSelectedCabinet}
                 />
               </div>
@@ -118,7 +122,11 @@ const MainPage = () => {
         {/* 사물함 선택 완료 -> cabinetRental 컴포넌트 표시 */}
         {selectedCabinet && (
           <div className="absolute inset-y-0 right-0 w-80 border-gray-400 border-l-2 pt-20 flex">
-            <SelectedCabinetInformation selectedCabinet={selectedCabinet} />
+            <SelectedCabinetInformation
+              selectedBuilding={selectedBuilding}
+              selectedFloor={selectedFloor}
+              selectedCabinet={selectedCabinet}
+            />
           </div>
         )}
       </div>

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -7,6 +7,8 @@ import RentalinfoCard from "@/components/Profile/RentalinfoCard";
 import ProfileSaveButton from "@/components/Profile/ProfileSaveButton";
 import CabinetFooterMenuButton from "@/components/CabinetFooterMenuButton";
 import SideNavigationLayout from "@/pages/SideNavigationLayout";
+import { useCabinetState } from "@/hooks/useCabinetState";
+
 const ProfilePage = () => {
   const { userData, userIsVisible, setUserIsVisible } = useUserData();
   const toggleSwitch = (): void => {
@@ -20,6 +22,7 @@ const ProfilePage = () => {
     isOpen,
     setIsOpen,
   } = useBuildingState();
+  const { setSelectedCabinet } = useCabinetState();
   const { searchInput, setSearchInput } = useSearch();
 
   return (
@@ -33,6 +36,7 @@ const ProfilePage = () => {
         setIsOpen={setIsOpen}
         searchInput={searchInput}
         setSearchInput={setSearchInput}
+        setSelectedCabinet={setSelectedCabinet} // 추가
       />
 
       {/* 건물 정보(좌측) */}

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -16,6 +16,7 @@ const SearchPage = () => {
   const {
     selectedBuilding,
     setSelectedBuilding,
+    selectedFloor,
     setSelectedFloor,
     isOpen,
     setIsOpen,
@@ -119,7 +120,11 @@ const SearchPage = () => {
 
       {/* 선택한 사물함 정보(우측) */}
       <div className="absolute inset-y-0 right-0 w-80 border-gray-400 border-l-2 pt-20 hidden md:flex">
-        <SelectedCabinetInformation selectedCabinet={selectedCabinet} />
+        <SelectedCabinetInformation
+          selectedBuilding={selectedBuilding}
+          selectedFloor={selectedFloor}
+          selectedCabinet={selectedCabinet}
+        />
       </div>
     </div>
   );

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -32,7 +32,7 @@ const SearchPage = () => {
     handleSearchKeyword,
     debouncedSearchKeywordApi,
   } = useSearch();
-  const { selectedCabinet } = useCabinetState();
+  const { selectedCabinet, setSelectedCabinet } = useCabinetState();
   const { handleClickResultButton } = useSearchResultButton();
 
   // 검색 결과 6개씩 보여주기 위한 변수
@@ -72,6 +72,7 @@ const SearchPage = () => {
         selectedBuilding={selectedBuilding}
         setSelectedBuilding={setSelectedBuilding}
         setSelectedFloor={setSelectedFloor}
+        setSelectedCabinet={setSelectedCabinet}
       />
 
       {/* 검색 관련 */}

--- a/src/pages/SideNavigationLayout.tsx
+++ b/src/pages/SideNavigationLayout.tsx
@@ -10,6 +10,7 @@ interface NavBuildingProps {
   selectedBuilding: string | null; // 선택된 건물의 인덱스 또는 null
   setSelectedBuilding: (name: string | null) => void; // 선택된 건물을 설정하는 함수
   setSelectedFloor: (floor: number | null) => void; // 선택된 층을 설정하는 함수
+  setSelectedCabinet: (cabinet: number | null) => void; // 추가 (드롭다운에서 건물 선택 시 사물함 정보도 초기화)
 }
 
 const SideNavigationLayout = ({
@@ -17,6 +18,7 @@ const SideNavigationLayout = ({
   selectedBuilding,
   setSelectedBuilding,
   setSelectedFloor,
+  setSelectedCabinet,
 }: NavBuildingProps) => {
   const { isOpen, setIsOpen, dropdownOutsideRef } = useBuildingState();
   const location = useLocation();
@@ -72,6 +74,7 @@ const SideNavigationLayout = ({
                     onClick={() => {
                       setSelectedBuilding(building.name); // 선택한 건물 업데이트
                       setSelectedFloor(null); // 건물 층수 초기화
+                      setSelectedCabinet(null);
                       setIsOpen(false); // 드롭다운 닫기
                     }}
                   >


### PR DESCRIPTION
## #️⃣연관된 이슈

> #26

## 📝작업 내용
> - 사물함 컴포넌트에 대한 API 요청
>     - 사물함 API 좌표(xPos, yPos)에 따라 사물함 버튼 컴포넌트 배치
>     - 사물함 상태에 따른 색상 표시

> - 사물함 정보 관련
>     - 사물함 클릭시 사물함 정보(건물, 층, 사물함 번호) 추가
>     - 건물, 층, 사물함이 모두 선택되어 있을 때만 사물함 정보 표시(우측)
>     - 건물 새로 선택하게 되면 기존 사물함 정보 표시 제거

### 스크린샷 (선택)
<img width="1708" alt="스크린샷 2024-11-17 오후 6 03 20" src="https://github.com/user-attachments/assets/51527c67-23b5-4147-8061-d7763ef78744">


<img width="1710" alt="스크린샷 2024-11-17 오후 6 01 19" src="https://github.com/user-attachments/assets/e458c7ba-8003-4420-9117-eaf3fc321cd1">

## 💬리뷰 요구사항(선택)

> 
