### PR TITLE
Feat: redux를 통한 accessToken 상태관리와 인터셉터로 토큰 재발급 api 요청 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "univ_fe",
       "version": "0.0.0",
       "dependencies": {
+        "@reduxjs/toolkit": "^2.3.0",
         "@types/lodash": "^4.17.13",
         "axios": "^1.7.7",
         "esbuild": "^0.24.0",
@@ -15,8 +16,10 @@
         "lodash-es": "^4.17.21",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-redux": "^9.1.2",
         "react-router": "^6.26.2",
         "react-router-dom": "^6.26.2",
+        "redux": "^5.0.1",
         "tailwindcss": "^3.4.12"
       },
       "devDependencies": {
@@ -2557,9 +2560,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.0.tgz",
-      "integrity": "sha512-vH9PiIMMwvhCx31Af3HiGzsVNULDbyVkHXwlemn/B0TFj/00ho3y55efXrUZTfQipxoHC5u4xq6zblww1zm1Ig==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.3.tgz",
+      "integrity": "sha512-2b/g5hRmpbb1o4GnTZax9N9m0FXzz9OV42ZzI4rDDMDuHUqigAiQCEWChBWCY4ztAGVRjoWT19v0yMmc5/L5kA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2729,6 +2732,30 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.3.0.tgz",
+      "integrity": "sha512-WC7Yd6cNGfHx8zf+iu+Q1UPTfEcXhQ+ATi7CV1hlrSAaQBdlPzg7Ww/wJHNQem7qG9rxmWoFCDCPubSvFObGzA==",
+      "license": "MIT",
+      "dependencies": {
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/@remix-run/router": {
@@ -3347,14 +3374,14 @@
       "version": "15.7.13",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.13.tgz",
       "integrity": "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.11",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.11.tgz",
       "integrity": "sha512-r6QZ069rFTjrEYgFdOck1gK7FLVsgJE7tTz0pQBczlBNUhBNk0MQH4UbnFSwjpQLMkLzgqvBBa+qGpLje16eTQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -3370,6 +3397,12 @@
       "dependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.8.1",
@@ -4107,9 +4140,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4216,7 +4249,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -5051,6 +5084,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-fresh": {
@@ -5959,6 +6002,29 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-redux": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.1.2.tgz",
+      "integrity": "sha512-0OA4dhM1W48l3uzmv6B7TXPCGmokUU4p1M44DGN2/D9a1FjVPukVjER1PcPX97jIg6aUeLq1XJo1IpfbgULn0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.3",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25",
+        "react": "^18.0",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
@@ -6020,6 +6086,21 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/regenerate": {
@@ -6096,6 +6177,12 @@
       "bin": {
         "regjsparser": "bin/parser"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -6738,6 +6825,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
+      "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@reduxjs/toolkit": "^2.3.0",
     "@types/lodash": "^4.17.13",
     "axios": "^1.7.7",
     "esbuild": "^0.24.0",
@@ -17,8 +18,10 @@
     "lodash-es": "^4.17.21",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-redux": "^9.1.2",
     "react-router": "^6.26.2",
     "react-router-dom": "^6.26.2",
+    "redux": "^5.0.1",
     "tailwindcss": "^3.4.12"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,7 @@
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import "./App.css";
+import { Provider } from "react-redux";
+import store from "@/redux/store/store";
 import MainPage from "@/pages/MainPage";
 import LoginPage from "@/pages/Login/LoginPage";
 import ErrorPage from "@/pages/ErrorPage";
@@ -9,7 +11,7 @@ import ProfilePage from "@/pages/ProfilePage";
 
 function App() {
   return (
-    <>
+    <Provider store={store}>
       <BrowserRouter>
         <Routes>
           <Route path="/main" element={<MainPage />} />
@@ -21,7 +23,7 @@ function App() {
           <Route path="/profile" element={<ProfilePage />} />
         </Routes>
       </BrowserRouter>
-    </>
+    </Provider>
   );
 }
 

--- a/src/api/axiosCredentialstate.tsx
+++ b/src/api/axiosCredentialstate.tsx
@@ -1,0 +1,8 @@
+import axios from "axios";
+
+axios.defaults.withCredentials = true;
+
+export default axios;
+//withCredential을 default로 설정하는게 편해보여서 만들었습니다.
+
+// 근데 이 친구 api 폴더에있는게 맞나... 싶네요

--- a/src/api/axiosCredentialstate.tsx
+++ b/src/api/axiosCredentialstate.tsx
@@ -1,8 +1,0 @@
-import axios from "axios";
-
-axios.defaults.withCredentials = true;
-
-export default axios;
-//withCredential을 default로 설정하는게 편해보여서 만들었습니다.
-
-// 근데 이 친구 api 폴더에있는게 맞나... 싶네요

--- a/src/api/axiosInterceptApi.tsx
+++ b/src/api/axiosInterceptApi.tsx
@@ -1,0 +1,31 @@
+import axios from "axios";
+import store from "@/redux/store/store";
+import { setAccessToken, clearAccessToken } from "@/redux/slice/authSlice";
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_BE_URL, // 모든 api 요청은 기본으로 localhost:8000 으로 보냅니다.
+  withCredentials: true, // 모든 api 요청은 withCredentials:true 설정입니다.
+});
+
+api.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const Request = error.config;
+    if (error.response.status === 401 && !Request._retry) {
+      Request._retry = true; // 무한 반복 막기
+      try {
+        const response = await api.post("/authn/token/access");
+        const newAccessToken = response.data.accessToken;
+        store.dispatch(setAccessToken(newAccessToken));
+        return api(Request);
+      } catch (refreshError) {
+        store.dispatch(clearAccessToken());
+        window.location.href = "/login";
+        return Promise.reject(refreshError);
+      }
+    }
+    return Promise.reject(error);
+  }
+);
+
+export default api;

--- a/src/api/axiosInterceptApi.tsx
+++ b/src/api/axiosInterceptApi.tsx
@@ -19,10 +19,16 @@ api.interceptors.response.use(
         store.dispatch(setAccessToken(newAccessToken));
         return api(Request);
       } catch (refreshError) {
+        console.error("refresh 토큰 만료", refreshError);
         store.dispatch(clearAccessToken());
         window.location.href = "/login";
         return Promise.reject(refreshError);
       }
+    }
+    if (error.response.status === 500) {
+      console.error("500에러", error);
+      window.location.href = "/login";
+      return Promise.reject(error);
     }
     return Promise.reject(error);
   }

--- a/src/api/cabinetCallApi.tsx
+++ b/src/api/cabinetCallApi.tsx
@@ -1,11 +1,10 @@
-import axios from "@/api/axiosCredentialstate";
-const CABINET_URL = import.meta.env.VITE_CABINET_URL;
+import api from "@/api/axiosInterceptApi";
 
 // 메인 페이지: 건물, 층 선택 시 호출되는 API
 export const cabinetCallApi = async (building: string, floor: number) => {
   try {
-    const response = await axios.get(
-      `${CABINET_URL}?building=${building}&floor=${floor}`
+    const response = await api.get(
+      `/cabient?building=${building}&floor=${floor}`
     );
     return response.data;
   } catch (error) {

--- a/src/api/cabinetCallApi.tsx
+++ b/src/api/cabinetCallApi.tsx
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios from "@/api/axiosCredentialstate";
 const CABINET_URL = import.meta.env.VITE_CABINET_URL;
 
 // 메인 페이지: 건물, 층 선택 시 호출되는 API

--- a/src/api/loginApi.tsx
+++ b/src/api/loginApi.tsx
@@ -1,18 +1,30 @@
-import axios from "@/api/axiosCredentialstate";
-const LOGIN_URL = import.meta.env.VITE_BE_URL; // VITE_LOGIN_URL 사용
-// 로그인 요청 재사용과 유지보수를 위한 모듈화
-interface loginApiProps {
+import api from "@/api/axiosInterceptApi";
+import { setAccessToken } from "@/redux/slice/authSlice";
+import { AppDispatch } from "@/redux/store/store";
+
+interface LoginApiProps {
   studentNumber: string;
   password: string;
 }
-export const loginApi = async ({ studentNumber, password }: loginApiProps) => {
+
+export const loginApi = async (
+  dispatch: AppDispatch,
+  { studentNumber, password }: LoginApiProps
+) => {
   try {
-    const response = await axios.post(`${LOGIN_URL}/authn/login`, {
+    const response = await api.post("/authn/login", {
       studentNumber,
       password,
     });
+
+    const accessToken = response.data.accessToken;
+
+    // Redux 상태에 accessToken 저장
+    dispatch(setAccessToken(accessToken));
+
     return { status: response.status, data: response.data };
   } catch (error) {
-    throw error;
+    console.error("loginApi 오류:", error);
+    throw error; // 에러를 호출한 쪽으로 전달
   }
 };

--- a/src/api/loginApi.tsx
+++ b/src/api/loginApi.tsx
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios from "@/api/axiosCredentialstate";
 const LOGIN_URL = import.meta.env.VITE_BE_URL; // VITE_LOGIN_URL 사용
 // 로그인 요청 재사용과 유지보수를 위한 모듈화
 interface loginApiProps {
@@ -13,6 +13,6 @@ export const loginApi = async ({ studentNumber, password }: loginApiProps) => {
     });
     return { status: response.status, data: response.data };
   } catch (error) {
-    return { status: error.response.status, error: error.response.data };
+    throw error;
   }
 };

--- a/src/api/logoutApi.tsx
+++ b/src/api/logoutApi.tsx
@@ -1,9 +1,11 @@
-import axios from "@/api/axiosCredentialstate";
-const LOGOUT_URL = import.meta.env.VITE_BE_URL; // VITE_LOGIN_URL 사용
+import api from "@/api/axiosInterceptApi";
+import { AppDispatch } from "@/redux/store/store";
+import { clearAccessToken } from "@/redux/slice/authSlice";
 
-export const logoutApi = async () => {
+export const logoutApi = async (distpatch: AppDispatch) => {
   try {
-    const response = await axios.post(`${LOGOUT_URL}/authn/logout`);
+    const response = await api.post("authn/logout");
+    distpatch(clearAccessToken());
     return { status: response.status, data: response.data };
   } catch (error) {
     return { status: error.response.status, data: error.response.data };

--- a/src/api/logoutApi.tsx
+++ b/src/api/logoutApi.tsx
@@ -1,17 +1,9 @@
-import axios from "axios";
+import axios from "@/api/axiosCredentialstate";
 const LOGOUT_URL = import.meta.env.VITE_BE_URL; // VITE_LOGIN_URL 사용
 
 export const logoutApi = async () => {
   try {
-    const response = await axios.post(
-      `${LOGOUT_URL}/authn/logout`,
-      {},
-      {
-        headers: {
-          Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
-        },
-      }
-    );
+    const response = await axios.post(`${LOGOUT_URL}/authn/logout`);
     return { status: response.status, data: response.data };
   } catch (error) {
     return { status: error.response.status, data: error.response.data };

--- a/src/api/searchKeywordApi.tsx
+++ b/src/api/searchKeywordApi.tsx
@@ -1,10 +1,9 @@
-import axios from "@/api/axiosCredentialstate";
-const SEARCH_URL = import.meta.env.VITE_SEARCH_URL;
+import api from "@/api/axiosInterceptApi";
 
 // // Search API 호출
 export const searchKeywordApi = async (keyword) => {
   try {
-    const response = await axios.get(`${SEARCH_URL}?keyword=${keyword}`);
+    const response = await api.get(`/cabinet/search?keyword=${keyword}`);
 
     const filterData = response.data.filter((inputValue) => {
       return inputValue.cabinetNumber.toString().includes(keyword);

--- a/src/api/searchKeywordApi.tsx
+++ b/src/api/searchKeywordApi.tsx
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios from "@/api/axiosCredentialstate";
 const SEARCH_URL = import.meta.env.VITE_SEARCH_URL;
 
 // // Search API 호출

--- a/src/api/searchResultsApi.tsx
+++ b/src/api/searchResultsApi.tsx
@@ -1,12 +1,10 @@
-import axios from "@/api/axiosCredentialstate";
-
-const SEARCH_URL = import.meta.env.VITE_SEARCH_URL;
+import api from "@/api/axiosInterceptApi";
 
 // // Search API 호출
 export const searchResultsApi = async (searchInput: string, page: number) => {
   try {
-    const response = await axios.get(
-      `${SEARCH_URL}/detail?keyword=${searchInput}&page=${page}`
+    const response = await api.get(
+      `/cabinet/search/detail?keyword=${searchInput}&page=${page}`
     );
     if (response && response.data) {
       return response; // 정상 응답 반환

--- a/src/api/searchResultsApi.tsx
+++ b/src/api/searchResultsApi.tsx
@@ -1,4 +1,5 @@
-import axios from "axios";
+import axios from "@/api/axiosCredentialstate";
+
 const SEARCH_URL = import.meta.env.VITE_SEARCH_URL;
 
 // // Search API 호출

--- a/src/api/userDataApi.tsx
+++ b/src/api/userDataApi.tsx
@@ -1,10 +1,9 @@
 // 유저 정보 조회 Api
-import axios from "@/api/axiosCredentialstate";
-const DATA_URL = import.meta.env.VITE_BE_URL; // VITE_LOGIN_URL 사용
+import api from "@/api/axiosInterceptApi";
 
 export const userDataApi = async () => {
   try {
-    const response = await axios.get(`${DATA_URL}/user/profile/me`);
+    const response = await api.get("/user/profile/me");
     return { status: response.status, data: response.data };
   } catch (error) {
     throw error; // 오류를 발생시켜 useUserData의 catch 블록으로 전달

--- a/src/api/userDataApi.tsx
+++ b/src/api/userDataApi.tsx
@@ -1,14 +1,10 @@
 // 유저 정보 조회 Api
-import axios from "axios";
+import axios from "@/api/axiosCredentialstate";
 const DATA_URL = import.meta.env.VITE_BE_URL; // VITE_LOGIN_URL 사용
 
 export const userDataApi = async () => {
   try {
-    const response = await axios.get(`${DATA_URL}/user/profile/me`, {
-      headers: {
-        Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
-      },
-    });
+    const response = await axios.get(`${DATA_URL}/user/profile/me`);
     return { status: response.status, data: response.data };
   } catch (error) {
     throw error; // 오류를 발생시켜 useUserData의 catch 블록으로 전달

--- a/src/api/userHistoryDataApi.tsx
+++ b/src/api/userHistoryDataApi.tsx
@@ -1,13 +1,9 @@
-import axios from "axios";
+import axios from "@/api/axiosCredentialstate";
 const HISTORY_DATA_URL = import.meta.env.VITE_BE_URL; // VITE_LOGIN_URL 사용
 
 export const userHistoryDataApi = async () => {
   try {
-    const response = await axios.get(`${HISTORY_DATA_URL}/cabinet/history`, {
-      headers: {
-        Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
-      },
-    });
+    const response = await axios.get(`${HISTORY_DATA_URL}/cabinet/history`);
     return { status: response.status, data: response.data };
   } catch (error) {
     throw error; // 오류를 발생시켜 useUserData의 catch 블록으로 전달

--- a/src/api/userHistoryDataApi.tsx
+++ b/src/api/userHistoryDataApi.tsx
@@ -1,9 +1,8 @@
-import axios from "@/api/axiosCredentialstate";
-const HISTORY_DATA_URL = import.meta.env.VITE_BE_URL; // VITE_LOGIN_URL 사용
+import api from "@/api/axiosInterceptApi";
 
 export const userHistoryDataApi = async () => {
   try {
-    const response = await axios.get(`${HISTORY_DATA_URL}/cabinet/history`);
+    const response = await api.get("/cabinet/history");
     return { status: response.status, data: response.data };
   } catch (error) {
     throw error; // 오류를 발생시켜 useUserData의 catch 블록으로 전달

--- a/src/api/userProfileInfoUpdateApi.tsx
+++ b/src/api/userProfileInfoUpdateApi.tsx
@@ -1,17 +1,11 @@
-import axios from "axios";
+import axios from "@/api/axiosCredentialstate";
 const DATA_URL = import.meta.env.VITE_BE_URL; // VITE_LOGIN_URL 사용
 
 export const userProfileInfoUpdateApi = async (userIsVisible: boolean) => {
   try {
-    const response = await axios.post(
-      `${DATA_URL}/user/profile/me`,
-      { isVisible: userIsVisible },
-      {
-        headers: {
-          Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
-        },
-      }
-    );
+    const response = await axios.post(`${DATA_URL}/user/profile/me`, {
+      isVisible: userIsVisible,
+    });
     return { status: response.status, data: response.data };
   } catch (error) {
     return { status: error.response.status, data: error.response.data };

--- a/src/api/userProfileInfoUpdateApi.tsx
+++ b/src/api/userProfileInfoUpdateApi.tsx
@@ -1,9 +1,8 @@
-import axios from "@/api/axiosCredentialstate";
-const DATA_URL = import.meta.env.VITE_BE_URL; // VITE_LOGIN_URL 사용
+import api from "@/api/axiosInterceptApi";
 
 export const userProfileInfoUpdateApi = async (userIsVisible: boolean) => {
   try {
-    const response = await axios.post(`${DATA_URL}/user/profile/me`, {
+    const response = await api.post("/user/profile/me", {
       isVisible: userIsVisible,
     });
     return { status: response.status, data: response.data };

--- a/src/hooks/useLogin.tsx
+++ b/src/hooks/useLogin.tsx
@@ -19,9 +19,6 @@ export const useLogin = () => {
         studentNumber,
         password,
       });
-      const { accessToken, refreshToken } = response.data;
-      localStorage.setItem("accessToken", accessToken);
-      localStorage.setItem("refreshToken", refreshToken);
       navigate("/main");
       setLoginSuccess(true); //로그인 성공
       console.log(response.status); // 로그인 상태 코드 로그

--- a/src/hooks/useLogin.tsx
+++ b/src/hooks/useLogin.tsx
@@ -1,9 +1,12 @@
+import { useDispatch } from "react-redux";
 import { loginApi } from "@/api/loginApi";
 import { useNavigate } from "react-router-dom";
 import { useLoginState } from "@/hooks/useLoginState";
+import { AppDispatch } from "@/redux/store/store";
 
 export const useLogin = () => {
   const navigate = useNavigate();
+  const dispatch = useDispatch<AppDispatch>(); // Redux dispatch 가져오기
   const {
     studentNumber,
     setStudentNumber,
@@ -15,19 +18,17 @@ export const useLogin = () => {
 
   const handleLogin = async () => {
     try {
-      const response = await loginApi({
-        studentNumber,
-        password,
-      });
+      const response = await loginApi(dispatch, { studentNumber, password });
       navigate("/main");
-      setLoginSuccess(true); //로그인 성공
+      setLoginSuccess(true); // 로그인 성공
       console.log(response.status); // 로그인 상태 코드 로그
     } catch (error) {
       console.error("로그인 중 오류가 발생했습니다:", error);
       console.log(error.response?.status || "오류를 알 수 없습니다.");
-      setLoginSuccess(false); //로그인 실패
+      setLoginSuccess(false); // 로그인 실패
     }
   };
+
   return {
     handleLogin,
     studentNumber,

--- a/src/hooks/useLogout.tsx
+++ b/src/hooks/useLogout.tsx
@@ -9,8 +9,6 @@ export const useLogout = () => {
       const response = await logoutApi();
       navigate(loginUrl);
       console.log(response.status);
-      localStorage.removeItem("accessToken");
-      localStorage.removeItem("refreshToken");
     } catch (error) {
       console.error("로그아웃 중 오류가 발생했습니다:", error);
       console.log(error.response?.status || "오류를 알 수 없습니다.");

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import App from "./App.tsx";
+import App from "./App";
 import "./index.css";
 
 createRoot(document.getElementById("root")!).render(

--- a/src/redux/slice/authSlice.tsx
+++ b/src/redux/slice/authSlice.tsx
@@ -1,0 +1,24 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+
+interface AuthState {
+  accessToken: string | null;
+}
+
+const initialState: AuthState = {
+  accessToken: null,
+};
+
+const authSlice = createSlice({
+  name: "auth", // Redux 상태 구분 식별자
+  initialState,
+  reducers: {
+    setAccessToken: (state, action: PayloadAction<string>) => {
+      state.accessToken = action.payload;
+    },
+    clearAccessToken: (state) => {
+      state.accessToken = null;
+    },
+  },
+});
+export const { setAccessToken, clearAccessToken } = authSlice.actions; // 디스패치를 위한 액션 생성자 함수
+export default authSlice.reducer; //Redux store에 리듀서를 등록하기 위함

--- a/src/redux/store/store.tsx
+++ b/src/redux/store/store.tsx
@@ -1,0 +1,13 @@
+import { configureStore } from "@reduxjs/toolkit";
+import authReducer from "@/redux/slice/authSlice";
+
+const store = configureStore({
+  reducer: {
+    auth: authReducer,
+  },
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;
+
+export default store;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #38 

## 📝작업 내용

> 1. withCredentials: true 를 사용하여 쿠키로 토큰 요청 로직 구현
>2. 새로운 파일로 api 요청시 baseURL 설정과 withCredentials 설정 true로 구현 -> 이제 axiosInterceptApi의 api를 통해 default로 설정 쓸 수 있습니다.
>3. 인터셉트 로직 구현 -> 잘되는 지 잘모르겠네요 아직 -> 응답에 401요청있을시 재발급 요청 로직 만약 재발급 요청마저 오류날 시에 로그인 페이지로 이동
>4. accessToken 상태관리 사용
>5. api 요청 파일들 전부 수정 + localstorage 관련 로직 삭제

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 사실 계속 오류도 나고 처음 쓰는 코드들 도 많아서 오류 제보와 함께 피드백 받습니다. 도와주세요!
