### PR TITLE
Feat: HistoryList 무한 스크롤 구현#58

### DIFF
--- a/src/api/userDataApi.tsx
+++ b/src/api/userDataApi.tsx
@@ -6,6 +6,7 @@ export const userDataApi = async () => {
     const response = await api.get("/user/profile/me");
     return { status: response.status, data: response.data };
   } catch (error) {
+    console.log("userDataApi 호출 중 오류", error);
     throw error; // 오류를 발생시켜 useUserData의 catch 블록으로 전달
   }
 };

--- a/src/api/userHistoryDataApi.tsx
+++ b/src/api/userHistoryDataApi.tsx
@@ -1,10 +1,13 @@
 import api from "@/api/axiosInterceptApi";
 
-export const userHistoryDataApi = async () => {
+export const userHistoryDataApi = async (page: number, pageSize: number) => {
   try {
-    const response = await api.get("/cabinet/history");
+    const response = await api.get("/cabinet/history", {
+      params: { page, pageSize },
+    });
     return { status: response.status, data: response.data };
   } catch (error) {
+    console.log("HistoryDataApi 호출 중 오류", error);
     throw error; // 오류를 발생시켜 useUserData의 catch 블록으로 전달
   }
 };

--- a/src/components/HistoryList.tsx
+++ b/src/components/HistoryList.tsx
@@ -7,12 +7,13 @@ interface HistoryListProp {
     startDate: string | null;
     endDate: string | null;
   }[];
+  setObserverRef: (node: HTMLTableRowElement) => void;
 }
 
-const HistoryList = ({ userHistoryData }: HistoryListProp) => {
+const HistoryList = ({ userHistoryData, setObserverRef }: HistoryListProp) => {
   return (
     <table className="w-full">
-      <thead className="bg-blue-500 text-white text-xl rounded-t-lg sticky top-0">
+      <thead className="bg-blue-500 text-white text-xl rounded-t-lg sticky z-10 top-0">
         <tr>
           <th className="w-80 table-cell text-center p-5">위치</th>
           <th className="w-1/3 table-cell text-center p-5">대여일</th>
@@ -21,7 +22,11 @@ const HistoryList = ({ userHistoryData }: HistoryListProp) => {
       </thead>
       <tbody>
         {userHistoryData.map((item, index) => (
-          <tr key={index} className="even:bg-white">
+          <tr
+            key={index}
+            ref={index === userHistoryData.length - 1 ? setObserverRef : null}
+            className="even:bg-white"
+          >
             <td className="w-80 table-cell text-center p-5 ">
               {item.building}-{item.section}-{item.cabinetNumber}-{item.floor}F
             </td>

--- a/src/hooks/useHistoryData.tsx
+++ b/src/hooks/useHistoryData.tsx
@@ -1,5 +1,6 @@
+import { useEffect, useState, useCallback } from "react";
+import { throttle } from "lodash";
 import { userHistoryDataApi } from "@/api/userHistoryDataApi";
-import { useEffect, useState } from "react";
 interface HistoryData {
   building: string;
   floor: number;
@@ -11,18 +12,45 @@ interface HistoryData {
 
 export const useHistoryData = () => {
   const [userHistoryData, setUserHistoryData] = useState<HistoryData[]>([]);
+  const [page, setPage] = useState<number>(1);
+  const [hasMoreResults, setHasMoreResults] = useState<boolean>(true);
+  const [lastElement, setLastElement] = useState<HTMLTableRowElement | null>(
+    null
+  );
+  const pageSize: number = 10;
   useEffect(() => {
-    const getHistoryData = async () => {
+    const fetchHistoryData = async () => {
       try {
-        const response = await userHistoryDataApi();
-        setUserHistoryData(response.data.results);
-        console.log(response.status);
+        const response = await userHistoryDataApi(page, pageSize);
+        if (response.data.results.length === 0) {
+          setHasMoreResults(false);
+        } else {
+          setUserHistoryData((prev) => [...prev, ...response.data.results]);
+        }
       } catch (error) {
-        console.error("로그인 중 오류가 발생했습니다:", error);
         console.log(error.response?.status || "오류를 알 수 없습니다.");
       }
     };
-    getHistoryData();
+    if (hasMoreResults) fetchHistoryData();
+  }, [page]);
+
+  useEffect(() => {
+    if (!lastElement) return;
+    const observer = new IntersectionObserver(
+      throttle((entries) => {
+        if (entries[0].isIntersecting && hasMoreResults) {
+          setPage((prev) => prev + 1);
+        }
+      }, 800), // 스크롤 내린지 0.8초 뒤에 api 호출되도록 설정
+      { threshold: 0.8 }
+    );
+    observer.observe(lastElement);
+    return () => observer.disconnect();
+  }, [lastElement, hasMoreResults]);
+
+  const setObserverRef = useCallback((node: HTMLTableRowElement) => {
+    setLastElement(node); // 해당 <tr> 요소를 관찰 대상으로 지정정
   }, []);
-  return { userHistoryData };
+
+  return { userHistoryData, setObserverRef };
 };

--- a/src/hooks/useHistoryData.tsx
+++ b/src/hooks/useHistoryData.tsx
@@ -18,6 +18,7 @@ export const useHistoryData = () => {
     null
   );
   const pageSize: number = 10;
+  const scrollPendingTime: number = 800;
   useEffect(() => {
     const fetchHistoryData = async () => {
       try {
@@ -41,7 +42,7 @@ export const useHistoryData = () => {
         if (entries[0].isIntersecting && hasMoreResults) {
           setPage((prev) => prev + 1);
         }
-      }, 800), // 스크롤 내린지 0.8초 뒤에 api 호출되도록 설정
+      }, scrollPendingTime), // 스크롤 내린지 0.8초 뒤에 api 호출되도록 설정
       { threshold: 0.8 }
     );
     observer.observe(lastElement);

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -6,7 +6,7 @@ import CabinetFooterMenuButton from "@/components/CabinetFooterMenuButton";
 import SideNavigationLayout from "@/pages/SideNavigationLayout";
 
 const HistoryPage = () => {
-  const { userHistoryData } = useHistoryData();
+  const { userHistoryData, setObserverRef } = useHistoryData();
   const {
     buildingList,
     selectedBuilding,
@@ -43,7 +43,10 @@ const HistoryPage = () => {
 
           {/* 히스토리 리스트 */}
           <div className="max-w-[60rem] w-[70%] max-h-[80vh] h-[90%] bg-gray-100 mt-5 border rounded-xl overflow-y-auto hidden-scrollbar shadow-lg">
-            <HistoryList userHistoryData={userHistoryData} />
+            <HistoryList
+              userHistoryData={userHistoryData}
+              setObserverRef={setObserverRef}
+            />
           </div>
         </main>
       </div>


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #58

## 📝작업 내용

>  히스토리 리스트 무한 스크롤 구현을 하였습니다.
맨 밑에 tr요소에 도달할 시에 0.8초 정도의 api 요청 텀을 두고 만들었습니다.

### 스크린샷 (선택)
<img width="560" alt="image" src="https://github.com/user-attachments/assets/b3b24257-6535-4866-9817-531f8e90be23" />


## 💬리뷰 요구사항(선택)

> 혹시 구현 필요한 최적화 가 있을까요?

> 그리고 git pull 받았는데 page와 pageSize 파라미터 요청은 매우 잘되지만 그 역순으로 results 값들이 오지는 않아서요 확인 한번 부탁드려요 @yeomin4242 

> 로딩화면은 이다음에 스켈레톤 ui 구현하면서 구현하겠습니다.
