### PR TITLE
Feat: logger level에 따른 logger 도입#60

### DIFF
--- a/src/api/cabinetCallApi.tsx
+++ b/src/api/cabinetCallApi.tsx
@@ -8,8 +8,6 @@ export const cabinetCallApi = async (building: string, floor: number) => {
     );
     return response.data;
   } catch (error) {
-    if (error === 404) {
-      console.log(error);
-    }
+    throw error;
   }
 };

--- a/src/api/cabinetDetailInfoApi.tsx
+++ b/src/api/cabinetDetailInfoApi.tsx
@@ -6,6 +6,6 @@ export const cabinetDetailInfoApi = async (cabinetId: number) => {
     const response = await api.get(`/cabinet/detail?cabinetId=${cabinetId}`);
     return response.data;
   } catch (error) {
-    console.error(error);
+    throw error;
   }
 };

--- a/src/api/loginApi.tsx
+++ b/src/api/loginApi.tsx
@@ -15,7 +15,6 @@ export const loginApi = async ({ studentNumber, password }: LoginApiProps) => {
     document.cookie = `accessToken=${accessToken}; path=/; Secure; SameSite=Strict`;
     return { status: response.status, data: response.data };
   } catch (error) {
-    console.error("loginApi 오류:", error);
     throw error; // 에러를 호출한 쪽으로 전달
   }
 };

--- a/src/api/rentApi.tsx
+++ b/src/api/rentApi.tsx
@@ -5,22 +5,9 @@ export const rentApi = async (cabinetId: number) => {
     const response = await api.post("/cabinet/rent", { cabinetId });
 
     if (response.status === 200) {
-      console.log(response.status);
-      return { success: true, message: "Rent successful", data: response.data };
+      return { success: true, message: "대여 성공", data: response.data };
     }
-  } catch (error: any) {
-    if (error) {
-      if (error === 400) {
-        console.error("Cabinet is already rented");
-        return { success: false, message: "Cabinet is already rented" };
-      }
-
-      if (error === 404) {
-        console.error("Cabinet not found");
-        return { success: false, message: "Cabinet not found" };
-      }
-    }
-    console.error("Unexpected error:", error);
-    return { success: false, message: "Unexpected error occurred" };
+  } catch (error) {
+    throw error;
   }
 };

--- a/src/api/rentApi.tsx
+++ b/src/api/rentApi.tsx
@@ -5,7 +5,7 @@ export const rentApi = async (cabinetId: number) => {
     const response = await api.post("/cabinet/rent", { cabinetId });
 
     if (response.status === 200) {
-      return { success: true, message: "대여 성공", data: response.data };
+      return { message: "대여 성공", data: response.data };
     }
   } catch (error) {
     throw error;

--- a/src/api/returnApi.tsx
+++ b/src/api/returnApi.tsx
@@ -6,7 +6,6 @@ export const returnApi = async (cabinetId: number) => {
 
     if (response.status === 200) {
       return {
-        success: true,
         message: "반납 성공",
         data: response.data,
       };

--- a/src/api/returnApi.tsx
+++ b/src/api/returnApi.tsx
@@ -5,26 +5,13 @@ export const returnApi = async (cabinetId: number) => {
     const response = await api.post("/cabinet/return", { cabinetId });
 
     if (response.status === 200) {
-      console.log(response.status);
       return {
         success: true,
-        message: "Cabinet Return Successful",
+        message: "반납 성공",
         data: response.data,
       };
     }
-  } catch (error: any) {
-    if (error) {
-      if (error === 400) {
-        console.error("Cabinet is already rented");
-        return { success: false, message: "Cabinet is already rented" };
-      }
-
-      if (error === 404) {
-        console.error("Cabinet not found");
-        return { success: false, message: "Cabinet not found" };
-      }
-    }
-    console.error("Unexpected error:", error);
-    return { success: false, message: "Unexpected error occurred" };
+  } catch (error) {
+    throw error;
   }
 };

--- a/src/api/searchKeywordApi.tsx
+++ b/src/api/searchKeywordApi.tsx
@@ -1,6 +1,5 @@
 import api from "@/api/axiosInterceptApi";
 
-// Search API 호출
 export const searchKeywordApi = async (keyword) => {
   try {
     const response = await api.get(`/cabinet/search?keyword=${keyword}`);
@@ -10,7 +9,6 @@ export const searchKeywordApi = async (keyword) => {
     );
     return filterData;
   } catch (error) {
-    console.log(error);
     return [];
   }
 };

--- a/src/api/searchResultsApi.tsx
+++ b/src/api/searchResultsApi.tsx
@@ -1,18 +1,16 @@
 import api from "@/api/axiosInterceptApi";
 
-// // Search API 호출
 export const searchResultsApi = async (searchInput: string, page: number) => {
   try {
     const response = await api.get(
       `/cabinet/search/detail?keyword=${searchInput}&page=${page}`
     );
     if (response && response.data) {
-      return response; // 정상 응답 반환
+      return response;
     } else {
-      throw new Error("응답 데이터가 없습니다."); // 데이터가 없을 경우 예외 처리
+      throw new Error("응답 데이터가 없습니다.");
     }
   } catch (error) {
-    console.error(error);
-    throw error; // 호출한 함수에서 처리할 수 있도록 에러 전달
+    throw error;
   }
 };

--- a/src/api/userDataApi.tsx
+++ b/src/api/userDataApi.tsx
@@ -6,7 +6,6 @@ export const userDataApi = async () => {
     const response = await api.get("/user/profile/me");
     return { status: response.status, data: response.data };
   } catch (error) {
-    console.log("userDataApi 호출 중 오류", error);
     throw error; // 오류를 발생시켜 useUserData의 catch 블록으로 전달
   }
 };

--- a/src/api/userHistoryDataApi.tsx
+++ b/src/api/userHistoryDataApi.tsx
@@ -7,7 +7,6 @@ export const userHistoryDataApi = async (page: number, pageSize: number) => {
     });
     return { status: response.status, data: response.data };
   } catch (error) {
-    console.log("HistoryDataApi 호출 중 오류", error);
     throw error; // 오류를 발생시켜 useUserData의 catch 블록으로 전달
   }
 };

--- a/src/components/BuildingSelectButton.tsx
+++ b/src/components/BuildingSelectButton.tsx
@@ -1,6 +1,5 @@
 // 건물, 층 선택 버튼
 import { BuildingData, SelectedCabinet } from "types/CabinetType";
-import { useCabinet } from "@/hooks/useCabinet";
 import { useSearch } from "@/hooks/useSearch";
 import { useSearchToMain } from "@/hooks/useSearchToMain";
 
@@ -24,7 +23,6 @@ const BuildingSelectButton = ({
   // search result와 동일한 쿼리스트링 페이지로 이동
   useSearchToMain(selectedBuilding, setSelectedBuilding, setSelectedFloor);
   const { setSearchParams } = useSearch();
-  const { fetchCabinetData } = useCabinet();
 
   return (
     <div>
@@ -59,7 +57,6 @@ const BuildingSelectButton = ({
                     onClick={() => {
                       setSelectedFloor(floor);
                       setSelectedCabinet(null);
-                      fetchCabinetData(buildingData.building, floor);
                       setSearchParams({
                         building: buildingData.building,
                         floor: floor.toString(),

--- a/src/hooks/useCabinet.tsx
+++ b/src/hooks/useCabinet.tsx
@@ -21,7 +21,13 @@ export const useCabinet = () => {
       setSelectedStatus(response.status);
       setIsMyCabinet(response.isMine);
       setExpiredAt(response.expiredAt);
-      log.info("API 호출 성공: cabinetDetailInfoApi");
+      log.info(
+        `API 호출 성공: cabinetDetailInfoApi, ${JSON.stringify(
+          response,
+          null,
+          2
+        )}`
+      );
       return response;
     } catch (error) {
       log.error("API 호출 중 에러 발생: cabinetDetailInfoApi");

--- a/src/hooks/useCabinet.tsx
+++ b/src/hooks/useCabinet.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { SelectedCabinet } from "types/CabinetType";
+import { log } from "@/utils/logger";
 import { cabinetDetailInfoApi } from "@/api/cabinetDetailInfoApi";
-import { cabinetCallApi } from "@/api/cabinetCallApi";
 
 export const useCabinet = () => {
   const [selectedCabinet, setSelectedCabinet] =
@@ -9,19 +9,6 @@ export const useCabinet = () => {
   const [selectedStatus, setSelectedStatus] = useState<string>(); // 사물함 status
   const [expiredAt, setExpiredAt] = useState<string | null>(null); // 반납 기한
   const [isMyCabinet, setIsMyCabinet] = useState<boolean>(); // 본인 사물함 여부
-
-  // 사물함 API 호출
-  const fetchCabinetData = async (building: string, floor: number) => {
-    try {
-      const response = await cabinetCallApi(building, floor);
-      console.log(200);
-      return response;
-    } catch (error) {
-      if (error === 404) {
-        console.error(404);
-      }
-    }
-  };
 
   // 사물함 세부 정보 API 호출
   const fetchCabinetDetailInformation = async (
@@ -34,10 +21,10 @@ export const useCabinet = () => {
       setSelectedStatus(response.status);
       setIsMyCabinet(response.isMine);
       setExpiredAt(response.expiredAt);
-      console.log(200);
+      log.info("API 호출 성공: cabinetDetailInfoApi");
       return response;
     } catch (error) {
-      console.error(error);
+      log.error("API 호출 중 에러 발생: cabinetDetailInfoApi");
     }
   };
 
@@ -72,6 +59,5 @@ export const useCabinet = () => {
     setIsMyCabinet,
     getStatusColor,
     fetchCabinetDetailInformation,
-    fetchCabinetData,
   };
 };

--- a/src/hooks/useCabinetActivation.tsx
+++ b/src/hooks/useCabinetActivation.tsx
@@ -1,6 +1,7 @@
 // 사물함 버튼 활성화 -> cabinetData 저장
 
 import { useState, useEffect } from "react";
+import { log } from "@/utils/logger";
 import { cabinetCallApi } from "@/api/cabinetCallApi";
 
 interface CabinetData {
@@ -31,30 +32,26 @@ export const useCabinetActivation = ({
 }: UseCabinetActivationProps) => {
   const [cabinetData, setCabinetData] = useState<CabinetData[]>([]);
 
-  const fetchCabinetButtonActivation = async (
-    building: string,
-    floor: number
-  ) => {
+  // 사물함 API 호출
+  const fetchCabinetData = async (building: string, floor: number) => {
     try {
       const response = await cabinetCallApi(building, floor);
       setCabinetData(response.cabinets);
-
+      log.info("API 호출 성공: cabinetCallApi");
       return response;
     } catch (error) {
-      if (error === 404) {
-        console.error(404);
-      }
+      log.error("API 호출 중 에러 발생: cabinetCallApi");
     }
   };
   useEffect(() => {
     if (selectedBuilding !== null && selectedFloor !== null) {
-      fetchCabinetButtonActivation(selectedBuilding.building, selectedFloor);
+      fetchCabinetData(selectedBuilding.building, selectedFloor);
     }
   }, [selectedBuilding, selectedFloor, isMyCabinet]);
 
   return {
     cabinetData,
     setCabinetData,
-    fetchCabinetButtonActivation,
+    fetchCabinetData,
   };
 };

--- a/src/hooks/useCabinetActivation.tsx
+++ b/src/hooks/useCabinetActivation.tsx
@@ -37,7 +37,9 @@ export const useCabinetActivation = ({
     try {
       const response = await cabinetCallApi(building, floor);
       setCabinetData(response.cabinets);
-      log.info("API 호출 성공: cabinetCallApi");
+      log.info(
+        `API 호출 성공: cabinetCallApi, ${JSON.stringify(response, null, 2)}`
+      );
       return response;
     } catch (error) {
       log.error("API 호출 중 에러 발생: cabinetCallApi");

--- a/src/hooks/useCabinetRental.tsx
+++ b/src/hooks/useCabinetRental.tsx
@@ -20,13 +20,13 @@ export const useCabinetRental = ({
     if (!selectedCabinet) return;
     try {
       const response = await rentApi(selectedCabinet.cabinetId);
-      if (response?.success) {
+      if (response) {
         setSelectedStatus(response.data.status);
         setExpiredAt(response.data.expiredAt);
         setIsMyCabinet(response.data.isMine);
         closeRentalModal();
       }
-      log.info("API 호출 성공: rentApi");
+      log.info(`API 호출 성공: rentApi, ${JSON.stringify(response, null, 2)}`);
     } catch (error) {
       log.error("API 호출 중 에러 발생: rentApi");
     }

--- a/src/hooks/useCabinetRental.tsx
+++ b/src/hooks/useCabinetRental.tsx
@@ -1,4 +1,5 @@
 import { rentApi } from "@/api/rentApi";
+import { log } from "@/utils/logger";
 
 interface UseCabinetRentalProps {
   selectedCabinet: { cabinetId: number; cabinetNumber: number } | null;
@@ -23,11 +24,11 @@ export const useCabinetRental = ({
         setSelectedStatus(response.data.status);
         setExpiredAt(response.data.expiredAt);
         setIsMyCabinet(response.data.isMine);
+        closeRentalModal();
       }
+      log.info("API 호출 성공: rentApi");
     } catch (error) {
-      console.error(error);
-    } finally {
-      closeRentalModal();
+      log.error("API 호출 중 에러 발생: rentApi");
     }
   };
 

--- a/src/hooks/useCabinetReturn.tsx
+++ b/src/hooks/useCabinetReturn.tsx
@@ -1,4 +1,5 @@
 import { returnApi } from "@/api/returnApi";
+import { log } from "@/utils/logger";
 
 interface UseCabinetReturnProps {
   selectedCabinet: { cabinetId: number; cabinetNumber: number } | null;
@@ -24,11 +25,13 @@ export const useCabinetReturn = ({
         setIsMyCabinet(response.data.isMine);
         closeReturnModal();
         setExpiredAt(null); // 반납 기간 초기화
+        log.info("API 호출 성공: returnApi");
         return response.data;
       } else {
         closeReturnModal();
       }
     } catch (error) {
+      log.error("API 호출 중 에러 발생: returnApi");
       closeReturnModal();
     }
   };

--- a/src/hooks/useCabinetReturn.tsx
+++ b/src/hooks/useCabinetReturn.tsx
@@ -20,12 +20,14 @@ export const useCabinetReturn = ({
     if (!selectedCabinet) return;
     try {
       const response = await returnApi(selectedCabinet.cabinetId);
-      if (response?.success) {
+      if (response) {
         setSelectedStatus(response.data.status);
         setIsMyCabinet(response.data.isMine);
         closeReturnModal();
         setExpiredAt(null); // 반납 기간 초기화
-        log.info("API 호출 성공: returnApi");
+        log.info(
+          `API 호출 성공: returnApi, ${JSON.stringify(response, null, 2)}`
+        );
         return response.data;
       } else {
         closeReturnModal();

--- a/src/hooks/useHandleLogin.tsx
+++ b/src/hooks/useHandleLogin.tsx
@@ -13,8 +13,7 @@ export const useHandleLogin = () => {
       const response = await loginApi({ studentNumber, password });
       navigate("/main");
       setLoginSuccess(true); // 로그인 성공
-      // console.log(response.status); // 로그인 상태 코드 로그
-      log.info("API 호출 성공: loginApi");
+      log.info(`API 호출 성공: loginApi, ${JSON.stringify(response, null, 2)}`);
     } catch (error) {
       // console.error("로그인 중 오류가 발생했습니다:", error);
       // console.log(error.response?.status || "오류를 알 수 없습니다.");

--- a/src/hooks/useHandleLogin.tsx
+++ b/src/hooks/useHandleLogin.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from "react-router-dom";
 import { useState } from "react";
+import { log } from "@/utils/logger";
 import { loginApi } from "@/api/loginApi";
 
 export const useHandleLogin = () => {
@@ -12,10 +13,12 @@ export const useHandleLogin = () => {
       const response = await loginApi({ studentNumber, password });
       navigate("/main");
       setLoginSuccess(true); // 로그인 성공
-      console.log(response.status); // 로그인 상태 코드 로그
+      // console.log(response.status); // 로그인 상태 코드 로그
+      log.info("API 호출 성공: loginApi");
     } catch (error) {
-      console.error("로그인 중 오류가 발생했습니다:", error);
-      console.log(error.response?.status || "오류를 알 수 없습니다.");
+      // console.error("로그인 중 오류가 발생했습니다:", error);
+      // console.log(error.response?.status || "오류를 알 수 없습니다.");
+      log.error("API 호출 중 에러 발생: loginApi");
       setLoginSuccess(false); // 로그인 실패
     }
   };

--- a/src/hooks/useHistoryData.tsx
+++ b/src/hooks/useHistoryData.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState, useCallback } from "react";
 import { throttle } from "lodash";
+import { log } from "@/utils/logger";
 import { userHistoryDataApi } from "@/api/userHistoryDataApi";
+
 interface HistoryData {
   building: string;
   floor: number;
@@ -28,8 +30,10 @@ export const useHistoryData = () => {
         } else {
           setUserHistoryData((prev) => [...prev, ...response.data.results]);
         }
+        log.info("API 호출 성공: userHistoryDataApi");
       } catch (error) {
-        console.log(error.response?.status || "오류를 알 수 없습니다.");
+        // console.log(error.response?.status || "오류를 알 수 없습니다.");
+        log.error("API 호출 중 에러 발생: userHistoryDataApi");
       }
     };
     if (hasMoreResults) fetchHistoryData();

--- a/src/hooks/useHistoryData.tsx
+++ b/src/hooks/useHistoryData.tsx
@@ -30,7 +30,13 @@ export const useHistoryData = () => {
         } else {
           setUserHistoryData((prev) => [...prev, ...response.data.results]);
         }
-        log.info("API 호출 성공: userHistoryDataApi");
+        log.info(
+          `API 호출 성공: userHistoryDataApi, ${JSON.stringify(
+            response,
+            null,
+            2
+          )}`
+        );
       } catch (error) {
         // console.log(error.response?.status || "오류를 알 수 없습니다.");
         log.error("API 호출 중 에러 발생: userHistoryDataApi");

--- a/src/hooks/useLogout.tsx
+++ b/src/hooks/useLogout.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from "react-router-dom";
+import { log } from "@/utils/logger";
 import { logoutApi } from "@/api/logoutApi";
 
 export const useLogout = () => {
@@ -8,10 +9,12 @@ export const useLogout = () => {
     try {
       const response = await logoutApi();
       navigate(loginUrl);
-      console.log(response.status);
+      // console.log(response.status);
+      log.info("API 호출 성공: logoutApi");
     } catch (error) {
-      console.error("로그아웃 중 오류가 발생했습니다:", error);
-      console.log(error.response?.status || "오류를 알 수 없습니다.");
+      // console.error("로그아웃 중 오류가 발생했습니다:", error);
+      // console.log(error.response?.status || "오류를 알 수 없습니다.");
+      log.error("API 호출 중 에러 발생: logoutApi");
     }
   };
   return { handleLogout };

--- a/src/hooks/useLogout.tsx
+++ b/src/hooks/useLogout.tsx
@@ -9,8 +9,9 @@ export const useLogout = () => {
     try {
       const response = await logoutApi();
       navigate(loginUrl);
-      // console.log(response.status);
-      log.info("API 호출 성공: logoutApi");
+      log.info(
+        `API 호출 성공: logoutApi, ${JSON.stringify(response, null, 2)}`
+      );
     } catch (error) {
       // console.error("로그아웃 중 오류가 발생했습니다:", error);
       // console.log(error.response?.status || "오류를 알 수 없습니다.");

--- a/src/hooks/useProfileSave.tsx
+++ b/src/hooks/useProfileSave.tsx
@@ -4,14 +4,17 @@ import { log } from "@/utils/logger";
 export const useProfileSave = (userIsVisible: boolean, saveState: boolean) => {
   const handleProfileSave = async () => {
     if (userIsVisible === saveState) {
-      // console.log("변경사항이없음");
       log.info("변경 사항 없음");
     } else {
       try {
         const response = await userProfileInfoUpdateApi(userIsVisible);
-        // console.log(userIsVisible);
-        // console.log(response.status);
-        log.info("API 호출 성공: userProfileInfoUpdateApi");
+        log.info(
+          `API 호출 성공: userProfileInfoUpdateApi, ${JSON.stringify(
+            response,
+            null,
+            2
+          )}`
+        );
       } catch (error) {
         // console.error(error);
         // console.log(error.response?.status || "오류를 알 수 없습니다.");

--- a/src/hooks/useProfileSave.tsx
+++ b/src/hooks/useProfileSave.tsx
@@ -1,16 +1,21 @@
 import { userProfileInfoUpdateApi } from "@/api/userProfileInfoUpdateApi";
+import { log } from "@/utils/logger";
+
 export const useProfileSave = (userIsVisible: boolean, saveState: boolean) => {
   const handleProfileSave = async () => {
     if (userIsVisible === saveState) {
-      console.log("변경사항이없음");
+      // console.log("변경사항이없음");
+      log.info("변경 사항 없음");
     } else {
       try {
         const response = await userProfileInfoUpdateApi(userIsVisible);
-        console.log(userIsVisible);
-        console.log(response.status);
+        // console.log(userIsVisible);
+        // console.log(response.status);
+        log.info("API 호출 성공: userProfileInfoUpdateApi");
       } catch (error) {
-        console.error(error);
-        console.log(error.response?.status || "오류를 알 수 없습니다.");
+        // console.error(error);
+        // console.log(error.response?.status || "오류를 알 수 없습니다.");
+        log.error("API 호출 중 에러 발생: userProfileInfoUpdateApi");
       }
     }
   };

--- a/src/hooks/useSearch.tsx
+++ b/src/hooks/useSearch.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { debounce, throttle } from "lodash";
+import { log } from "@/utils/logger";
 import { searchResultsApi } from "@/api/searchResultsApi";
 import { searchKeywordApi } from "@/api/searchKeywordApi";
 
@@ -47,8 +48,9 @@ export const useSearch = () => {
         const response = await searchKeywordApi(keyword);
         setSearchResults(response);
         setShowGridResults(false);
+        log.info("API 호출 성공: searchKeywordApi");
       } catch (error) {
-        console.error(error);
+        log.error("API 호출 중 에러 발생: searchKeywordApi");
       }
     }
   };
@@ -76,9 +78,9 @@ export const useSearch = () => {
       } else {
         setIsLoading(false); // 마지막 페이지인 경우 로딩 종료
       }
-      console.log("현재 페이지", page);
+      log.info("API 호출 성공: searchResultsApi");
     } catch (error) {
-      console.error("검색 실패:", error);
+      log.error("API 호출 중 에러 발생: searchResultsApi");
     } finally {
       setIsLoading(false); // 로딩 상태 해제
     }

--- a/src/hooks/useSearch.tsx
+++ b/src/hooks/useSearch.tsx
@@ -48,7 +48,13 @@ export const useSearch = () => {
         const response = await searchKeywordApi(keyword);
         setSearchResults(response);
         setShowGridResults(false);
-        log.info("API 호출 성공: searchKeywordApi");
+        log.info(
+          `API 호출 성공: searchKeywordApi, ${JSON.stringify(
+            response,
+            null,
+            2
+          )}`
+        );
       } catch (error) {
         log.error("API 호출 중 에러 발생: searchKeywordApi");
       }
@@ -78,7 +84,9 @@ export const useSearch = () => {
       } else {
         setIsLoading(false); // 마지막 페이지인 경우 로딩 종료
       }
-      log.info("API 호출 성공: searchResultsApi");
+      log.info(
+        `API 호출 성공: searchResultsApi, ${JSON.stringify(data, null, 2)}`
+      );
     } catch (error) {
       log.error("API 호출 중 에러 발생: searchResultsApi");
     } finally {

--- a/src/hooks/useSearchInput.tsx
+++ b/src/hooks/useSearchInput.tsx
@@ -15,7 +15,7 @@ export const useSearchInput = ({
   const slicedSearchResults = 6;
 
   // searchInput 변경 시마다 디바운스 적용된 API 호출
-  const handleInputRelatedSearch = (e) => {
+  const handleInputRelatedSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
     const keyword = e.target.value;
     setSearchInput(keyword);
     debouncedSearchKeywordApi(keyword);

--- a/src/hooks/useSearchResultButton.tsx
+++ b/src/hooks/useSearchResultButton.tsx
@@ -36,7 +36,9 @@ export const useSearchResultButton = () => {
           floor,
         });
       }
-      log.info("API 호출 성공: cabinetCallApi");
+      log.info(
+        `API 호출 성공: cabinetCallApi, ${JSON.stringify(response, null, 2)}`
+      );
     } catch (error) {
       log.error("API 호출 중 에러 발생: cabinetCallApi");
     }

--- a/src/hooks/useSearchResultButton.tsx
+++ b/src/hooks/useSearchResultButton.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router";
+import { log } from "@/utils/logger";
 import { cabinetCallApi } from "@/api/cabinetCallApi";
 
 interface filteredCabinetDetailProps {
@@ -35,8 +36,9 @@ export const useSearchResultButton = () => {
           floor,
         });
       }
+      log.info("API 호출 성공: cabinetCallApi");
     } catch (error) {
-      console.error(error);
+      log.error("API 호출 중 에러 발생: cabinetCallApi");
     }
   };
 

--- a/src/hooks/useUserData.tsx
+++ b/src/hooks/useUserData.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { UserData } from "types/UserType";
+import { log } from "@/utils/logger";
 import { userDataApi } from "@/api/userDataApi";
 
 const defaultUserData: UserData = {
@@ -33,15 +34,17 @@ export const useUserData = () => {
           rentCabinetInfo:
             data.rentCabinetInfo || defaultUserData.rentCabinetInfo,
         });
-        console.log(data);
+        // console.log(data);
         setUserIsVisible(data.isVisible);
-        console.log(response.status);
+        // console.log(response.status);
+        log.info("API 호출 성공: userDataApi");
       } catch (error) {
         if (error.response?.status === 401) {
           navigate("/login");
         }
-        console.error("로그인 중 오류가 발생했습니다:", error);
-        console.log(error.response?.status || "오류를 알 수 없습니다.");
+        log.error("API 호출 중 에러 발생: userDataApi");
+        log.error("로그인 중 오류가 발생했습니다:");
+        // console.log(error.response?.status || "오류를 알 수 없습니다.");
       }
     };
     getData();

--- a/src/hooks/useUserData.tsx
+++ b/src/hooks/useUserData.tsx
@@ -34,10 +34,10 @@ export const useUserData = () => {
           rentCabinetInfo:
             data.rentCabinetInfo || defaultUserData.rentCabinetInfo,
         });
-        // console.log(data);
         setUserIsVisible(data.isVisible);
-        // console.log(response.status);
-        log.info("API 호출 성공: userDataApi");
+        log.info(
+          `API 호출 성공: userDataApi, ${JSON.stringify(response, null, 2)}`
+        );
       } catch (error) {
         if (error.response?.status === 401) {
           navigate("/login");

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,6 +1,6 @@
-type LogLevel = "DEBUG" | "INFO" | "WARN" | "ERROR" | "FATAL";
+type LogLevel = "DEBUG" | "INFO" | "WARN" | "ERROR";
 const LOG_LEVEL: LogLevel = "INFO"; // 현재 로그 레벨을 정의 (레벨에 따라 보여지는 로그가 정해짐)
-const levels: LogLevel[] = ["DEBUG", "INFO", "WARN", "ERROR", "FATAL"];
+const levels: LogLevel[] = ["DEBUG", "INFO", "WARN", "ERROR"];
 
 /**
  * 로그를 출력하는 함수
@@ -21,7 +21,6 @@ export const log = (level: LogLevel, message: string): void => {
         console.warn(`[WARN] - ${message}`);
         break;
       case "ERROR":
-      case "FATAL": // ERROR와 FATAL은 동일하게 처리
         console.error(`[${level}] - ${message}`);
         break;
       default:
@@ -35,4 +34,3 @@ log.debug = (message: string) => log("DEBUG", message);
 log.info = (message: string) => log("INFO", message);
 log.warn = (message: string) => log("WARN", message);
 log.error = (message: string) => log("ERROR", message);
-log.fatal = (message: string) => log("FATAL", message);

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,38 @@
+type LogLevel = "DEBUG" | "INFO" | "WARN" | "ERROR" | "FATAL";
+const LOG_LEVEL: LogLevel = "INFO"; // 현재 로그 레벨을 정의 (레벨에 따라 보여지는 로그가 정해짐)
+const levels: LogLevel[] = ["DEBUG", "INFO", "WARN", "ERROR", "FATAL"];
+
+/**
+ * 로그를 출력하는 함수
+ * @param level 로그 레벨
+ * @param message 로그 메시지
+ **/
+
+export const log = (level: LogLevel, message: string): void => {
+  if (levels.indexOf(level) >= levels.indexOf(LOG_LEVEL)) {
+    switch (level) {
+      case "DEBUG":
+        console.debug(`[DEBUG] - ${message}`);
+        break;
+      case "INFO":
+        console.info(`[INFO] - ${message}`);
+        break;
+      case "WARN":
+        console.warn(`[WARN] - ${message}`);
+        break;
+      case "ERROR":
+      case "FATAL": // ERROR와 FATAL은 동일하게 처리
+        console.error(`[${level}] - ${message}`);
+        break;
+      default:
+        console.log(`[${level}] - ${message}`);
+        break;
+    }
+  }
+};
+
+log.debug = (message: string) => log("DEBUG", message);
+log.info = (message: string) => log("INFO", message);
+log.warn = (message: string) => log("WARN", message);
+log.error = (message: string) => log("ERROR", message);
+log.fatal = (message: string) => log("FATAL", message);


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #60 

## 📝작업 내용

> - 간단하게 console을 커스텀하여 기존 console.log를 수정/제거하였습니다.
> - api 함수 부분의 console은 지우고, api를 호출하는 함수에서 로그가 찍히도록 수정하였습니다.
> - logger.ts에 `LOG_LEVEL`에 info를 정의해서 info를 포함한 warn, error, fatal만 콘솔에 찍히도록 설정해두었습니다
>     - 로그 레벨: https://sharonprogress.tistory.com/198

### 스크린샷 (선택)
<img width="550" alt="스크린샷 2025-01-28 오후 5 07 50" src="https://github.com/user-attachments/assets/4ffab228-8a45-40d0-84ce-9f43a90e81a6" />

+ 추가
<img width="341" alt="image" src="https://github.com/user-attachments/assets/bbf03ee2-3824-45a3-b8f2-be5cd51e6c5c" />


## 💬리뷰 요구사항(선택)

> - sentry와 같은 로깅방식도 고려해보았는데, 추후 규모가 커질 때 무료버전을 도입하면 좋을 것 같아서 일단은 배제해두었습니다.
> - 웅기님이 작성하신 console은 혹시 몰라서 일단 주석 처리해두었습니다! 
> - 이렇게 logger를 도입하는 게 맞는건지 피드백 주시면 감사하겠습니당