### PR TITLE
Feat: CabinetButton, Profile 페이지 컴포넌트 스켈레톤 UI 구현

### DIFF
--- a/src/components/Cabinet/CabinetButtonLayout.tsx
+++ b/src/components/Cabinet/CabinetButtonLayout.tsx
@@ -1,7 +1,8 @@
 // 사물함 배열 관련
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useCabinet } from "@/hooks/useCabinet";
 import { useCabinetActivation } from "@/hooks/useCabinetActivation";
+import CabinetButtonSkeleton from "../Skeleton/CabinetButtonSkeleton";
 
 interface CabinetButtonLayoutProps {
   selectedBuilding: { building: string } | null;
@@ -22,7 +23,7 @@ const CabinetButtonLayout = ({
   fetchCabinetDetailInformation,
 }: CabinetButtonLayoutProps) => {
   const { getStatusColor } = useCabinet();
-  const { cabinetData } = useCabinetActivation({
+  const { cabinetData, loading } = useCabinetActivation({
     selectedBuilding,
     selectedFloor,
     isMyCabinet,
@@ -39,31 +40,35 @@ const CabinetButtonLayout = ({
 
   return (
     <div className="w-full h-[80%] flex items-center justify-center">
-      <div className="relative h-[30rem] overflow-scroll lg:w-[67rem] md:w-[80%] sm:w-[75%] w-[100%]">
-        {cabinetData.map((cabinet) => {
-          return (
-            <button
-              key={cabinet.cabinetNumber}
-              className={`absolute w-16 h-20 rounded-md hover:bg-opacity-80 flex items-end text-sm p-2
+      {loading ? (
+        <CabinetButtonSkeleton />
+      ) : (
+        <div className="relative h-[30rem] overflow-scroll lg:w-[67rem] md:w-[80%] sm:w-[75%] w-[100%]">
+          {cabinetData.map((cabinet) => {
+            return (
+              <button
+                key={cabinet.cabinetNumber}
+                className={`absolute w-16 h-20 rounded-md hover:bg-opacity-80 flex items-end text-sm p-2
                 ${getStatusColor(cabinet.status, cabinet.isMine)} 
                 
               `}
-              style={{
-                top: `${350 - cabinet.cabinetYPos * 100}px`, // API에서 받은 yPos 사용
-                left: `${cabinet.cabinetXPos * 90}px`, // API에서 받은 xPos 사용
-              }}
-              onClick={() => {
-                fetchCabinetDetailInformation(
-                  cabinet.id,
-                  cabinet.cabinetNumber
-                );
-              }}
-            >
-              {cabinet.cabinetNumber}
-            </button>
-          );
-        })}
-      </div>
+                style={{
+                  top: `${350 - cabinet.cabinetYPos * 100}px`, // API에서 받은 yPos 사용
+                  left: `${cabinet.cabinetXPos * 90}px`, // API에서 받은 xPos 사용
+                }}
+                onClick={() => {
+                  fetchCabinetDetailInformation(
+                    cabinet.id,
+                    cabinet.cabinetNumber
+                  );
+                }}
+              >
+                {cabinet.cabinetNumber}
+              </button>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/Cabinet/CabinetButtonLayout.tsx
+++ b/src/components/Cabinet/CabinetButtonLayout.tsx
@@ -1,5 +1,5 @@
 // 사물함 배열 관련
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useCabinet } from "@/hooks/useCabinet";
 import { useCabinetActivation } from "@/hooks/useCabinetActivation";
 import CabinetButtonSkeleton from "../Skeleton/CabinetButtonSkeleton";

--- a/src/components/Cabinet/CabinetButtonLayout.tsx
+++ b/src/components/Cabinet/CabinetButtonLayout.tsx
@@ -2,7 +2,7 @@
 import { useEffect } from "react";
 import { useCabinet } from "@/hooks/useCabinet";
 import { useCabinetActivation } from "@/hooks/useCabinetActivation";
-import CabinetButtonSkeleton from "../Skeleton/CabinetButtonSkeleton";
+import CabinetButtonSkeleton from "@/components/Skeleton/CabinetButtonSkeleton";
 
 interface CabinetButtonLayoutProps {
   selectedBuilding: { building: string } | null;

--- a/src/components/Error/ErrorComponent.tsx
+++ b/src/components/Error/ErrorComponent.tsx
@@ -8,7 +8,7 @@ const ErrorCompoenent = () => {
         404 Not Found
       </h1>
       {/* SVG 아이콘 크기 조정 */}
-      <LogoSVG className="w-32 h-32 sl:w-64 sl:h-64 mb-5" />
+      <LogoSVG className="w-32 h-32 sl:w-64 sl:h-64 mb-5 animate-spin" />
       <p className="text-lg sl:text-xl text-white mb-2">
         원하시는 페이지를 찾을 수 없습니다.
       </p>

--- a/src/components/Profile/ProfileInfoCard.tsx
+++ b/src/components/Profile/ProfileInfoCard.tsx
@@ -12,7 +12,7 @@ const ProfileInfoCard = ({
   phoneNumber,
 }: ProfileInfoCardProps) => {
   return (
-    <div className="p-10 w-96 sl:w-full bg-neutral-100 rounded-2xl flex-col justify-start items-start gap-5 inline-flex shadow-md">
+    <div className="p-10 w-96 sl:w-full bg-neutral-150 rounded-2xl flex-col justify-start items-start gap-5 inline-flex shadow-md">
       <div className="justify-start items-start inline-flex text-black text-lg sl:text-xl font-bold">
         프로필
       </div>
@@ -46,7 +46,7 @@ const ProfileInfoCard = ({
           />
         </div>
       </div>
-      <div className="px-5 py-5 w-80 text-black  bg-white rounded-lg flex flex-col justify-start items-start gap-5 sl:gap-8 shadow">
+      <div className="px-5 py-5 w-80 h-32 text-black  bg-white rounded-lg flex flex-col justify-start items-start gap-5 sl:gap-8 shadow">
         <div className="justify-between text-sm sl:text-base inline-flex w-full">
           <div>학번</div>
           <div className="font-bold">

--- a/src/components/Profile/RentalinfoCard.tsx
+++ b/src/components/Profile/RentalinfoCard.tsx
@@ -5,7 +5,7 @@ interface RentalInfoCardProp {
 }
 const RentalInfoCard = ({ rentCabinetInfo }: RentalInfoCardProp) => {
   return (
-    <div className="p-10 w-96 sl:w-full bg-neutral-100 rounded-2xl flex-col justify-start items-start gap-5 inline-flex shadow-md">
+    <div className="p-10 w-96 sl:w-full bg-neutral-150 rounded-2xl flex-col justify-start items-start gap-5 inline-flex shadow-md">
       <div className="justify-start items-start inline-flex text-black text-xl font-bold">
         대여정보
       </div>
@@ -29,7 +29,7 @@ const RentalInfoCard = ({ rentCabinetInfo }: RentalInfoCardProp) => {
             </div>
           </div>
         </div>
-        <div className="px-5 py-5 w-80 text-black  bg-white rounded-lg flex flex-col justify-start items-start gap-5 shadow">
+        <div className="px-5 py-5 w-80 mt-3 h-32 text-black   bg-white rounded-lg flex flex-col justify-start items-start gap-5 shadow">
           <div className="justify-between items-start inline-flex w-full">
             <div>시작일</div>
             <div className="font-bold">{`${

--- a/src/components/Skeleton/CabinetButtonSkeleton.tsx
+++ b/src/components/Skeleton/CabinetButtonSkeleton.tsx
@@ -1,0 +1,27 @@
+const CanbinetButtonSkeleton = () => {
+  const columns = 12;
+  const rows = 4;
+
+  return (
+    <div className="w-full h-[80%] flex items-center justify-center">
+      <div className="relative h-[30rem] overflow-scroll lg:w-[67rem] md:w-[80%] sm:w-[75%] w-[100%]">
+        {Array.from({ length: columns * rows }).map((_, index) => {
+          const row = Math.floor(index / columns);
+          const column = index % columns;
+          return (
+            <div
+              key={index}
+              className="absolute w-16 h-20 rounded-md bg-gray-300 animate-pulse"
+              style={{
+                top: `${50 + row * 100}px`,
+                left: `${column * 90}px`,
+              }}
+            ></div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default CanbinetButtonSkeleton;

--- a/src/components/Skeleton/ProfileSkeleton.tsx
+++ b/src/components/Skeleton/ProfileSkeleton.tsx
@@ -1,0 +1,12 @@
+const ProfileSkeleton = () => {
+  return (
+    <div className="p-10 w-96 sl:w-full bg-neutral-150 rounded-2xl flex flex-col justify-start items-start gap-5 animate-pulse shadow-md">
+      <div className="w-24 h-8 bg-gray-200 rounded"></div>
+      <div className="w-32 h-16 bg-gray-200 rounded"></div>
+      <div className="w-24 h-8 bg-gray-200 rounded"></div>
+      <div className="px-5 py-5 w-80 h-32 bg-white rounded-lg flex flex-col justify-start items-start gap-5 shadow"></div>
+    </div>
+  );
+};
+
+export default ProfileSkeleton;

--- a/src/hooks/useCabinetActivation.tsx
+++ b/src/hooks/useCabinetActivation.tsx
@@ -30,12 +30,14 @@ export const useCabinetActivation = ({
   isMyCabinet,
 }: UseCabinetActivationProps) => {
   const [cabinetData, setCabinetData] = useState<CabinetData[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
 
   const fetchCabinetButtonActivation = async (
     building: string,
     floor: number
   ) => {
     try {
+      setLoading(true);
       const response = await cabinetCallApi(building, floor);
       setCabinetData(response.cabinets);
 
@@ -44,6 +46,8 @@ export const useCabinetActivation = ({
       if (error === 404) {
         console.error(404);
       }
+    } finally {
+      setLoading(false);
     }
   };
   useEffect(() => {
@@ -56,5 +60,6 @@ export const useCabinetActivation = ({
     cabinetData,
     setCabinetData,
     fetchCabinetButtonActivation,
+    loading,
   };
 };

--- a/src/hooks/useUserData.tsx
+++ b/src/hooks/useUserData.tsx
@@ -22,10 +22,12 @@ const defaultUserData: UserData = {
 export const useUserData = () => {
   const [userData, setUserData] = useState<UserData>(defaultUserData);
   const [userIsVisible, setUserIsVisible] = useState<boolean>(false);
+  const [loading, setLoding] = useState<boolean>(true);
   const navigate = useNavigate();
   useEffect(() => {
     const getData = async () => {
       try {
+        setLoding(true);
         const response = await userDataApi();
         const data = response.data;
         setUserData({
@@ -42,9 +44,11 @@ export const useUserData = () => {
         }
         console.error("로그인 중 오류가 발생했습니다:", error);
         console.log(error.response?.status || "오류를 알 수 없습니다.");
+      } finally {
+        setLoding(false);
       }
     };
     getData();
-  }, []);
-  return { userData, userIsVisible, setUserIsVisible };
+  }, [navigate]);
+  return { userData, userIsVisible, setUserIsVisible, loading };
 };

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -8,10 +8,11 @@ import RentalInfoCard from "@/components/Profile/RentalInfoCard";
 import CabinetFooterMenuButton from "@/components/CabinetFooterMenuButton";
 import SubmitAndNavigateButton from "@/components/SubmitAndNavigateButton";
 import ConfirmModalView from "@/components/ConfirmModalView";
+import ProfileSkeleton from "@/components/Skeleton/ProfileSkeleton";
 import SideNavigationLayout from "@/pages/SideNavigationLayout";
 
 const ProfilePage = () => {
-  const { userData, userIsVisible, setUserIsVisible } = useUserData();
+  const { userData, userIsVisible, setUserIsVisible, loading } = useUserData();
 
   const { handleProfileSave } = useProfileSave(
     userIsVisible,
@@ -71,16 +72,24 @@ const ProfilePage = () => {
         <main className="ml-0 md:ml-40 flex-grow flex flex-col items-center justify-center">
           <div className="flex flex-col md:flex-row gap-20 ">
             {/* 프로필 */}
-            <ProfileInfoCard
-              toggleSwitch={toggleSwitch}
-              name={userData.name}
-              userIsVisible={userIsVisible}
-              affiliation={userData.affiliation}
-              studentNumber={userData.studentNumber}
-              phoneNumber={userData.phoneNumber}
-            />
-            {/* 대여정보 */}
-            <RentalInfoCard rentCabinetInfo={userData.rentCabinetInfo} />
+            {loading ? (
+              <ProfileSkeleton />
+            ) : (
+              <ProfileInfoCard
+                toggleSwitch={toggleSwitch}
+                name={userData.name}
+                userIsVisible={userIsVisible}
+                affiliation={userData.affiliation}
+                studentNumber={userData.studentNumber}
+                phoneNumber={userData.phoneNumber}
+              />
+            )}
+
+            {loading ? (
+              <ProfileSkeleton />
+            ) : (
+              <RentalInfoCard rentCabinetInfo={userData.rentCabinetInfo} />
+            )}
           </div>
           <SubmitAndNavigateButton
             className={`mt-10 mb-10 w-40 h-16 ${

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,6 +8,7 @@ module.exports = {
         subText: "#767676",
         accentText: "#EB5757",
         background: "#f2f2f2",
+        "neutral-150": "#f0f0f0",
       },
       fontFamily: {
         sans: ["Pretendard", "sans-serif"],


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #62 

## 📝작업 내용
> 프로필 페이지의 프로필과 대여정보의 스켈레톤 ui를 구현했습니다. (tailwind pulse 애니메이션)

> https://github.com/user-attachments/assets/6affeab4-5849-41bb-993a-1d9bb1e678f0


> 이제 스켈레톤 ui를 구현하면서 tailwind에서 제공하는 애니메이션 css 가 있길래 몇개 봤는데 그중 spin 도 있더라구요 그래서 바로 에러페이지 사물함 돌아가게 만들어 봤습니다

> https://github.com/user-attachments/assets/e860f4e6-4bae-49ab-9ed5-76b32b2fd4fd

> 메인페이지 cabinetbutton 도 스켈레톤 ui를 구현했습니다. (tailwind pulse 애니메이션)

> https://github.com/user-attachments/assets/dcdc3fe7-0685-4221-b583-afcb84f4a68a


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 나머지 api 로딩( 로그인 , 무한스크롤 ) 은 로딩 스피너를 활용해볼까 합니다.
> 자유로운 리뷰 부탁 드립니다~
