### PR TITLE
Feat: 상태관리 API 연동 #83

### DIFF
--- a/src/api/adminChangeStatusApi.tsx
+++ b/src/api/adminChangeStatusApi.tsx
@@ -1,14 +1,15 @@
 import api from "@/api/axiosInterceptApi";
 
 export const adminChangeStatusApi = async (
-  cabinetId: number,
+  cabinetId: number[],
   newStatus: string,
+  reason?: string | null,
 ) => {
   try {
-    // TODO: cabinetId -> array 형태로 변경 예정
     const response = await api.post("/cabinet/admin/change/status", {
       cabinetId,
       newStatus,
+      reason,
     });
     if (response.status === 200) {
       return {

--- a/src/api/adminChangeStatusApi.tsx
+++ b/src/api/adminChangeStatusApi.tsx
@@ -1,13 +1,13 @@
 import api from "@/api/axiosInterceptApi";
 
 export const adminChangeStatusApi = async (
-  cabinetId: number[],
+  cabinetIds: number[],
   newStatus: string,
   reason: string | null,
 ) => {
   try {
     const response = await api.post("/cabinet/admin/change/status", {
-      cabinetId,
+      cabinetIds,
       newStatus,
       reason,
     });

--- a/src/api/adminChangeStatusApi.tsx
+++ b/src/api/adminChangeStatusApi.tsx
@@ -3,7 +3,7 @@ import api from "@/api/axiosInterceptApi";
 export const adminChangeStatusApi = async (
   cabinetId: number[],
   newStatus: string,
-  reason?: string | null,
+  reason: string | null,
 ) => {
   try {
     const response = await api.post("/cabinet/admin/change/status", {

--- a/src/components/Admin/Cabinet/AdminCabinetInformationDisplay.tsx
+++ b/src/components/Admin/Cabinet/AdminCabinetInformationDisplay.tsx
@@ -1,4 +1,8 @@
-import { CabinetInfo, SelectedCabinet, StatusData } from "@/types/CabinetType";
+import {
+  SelectedCabinet,
+  SelectedCabinetInfo,
+  StatusData,
+} from "@/types/CabinetType";
 import { SelectedMultiCabinetsData } from "@/types/MultiCabinetType";
 import { formatDate } from "@/utils/formatDate";
 import CabinetActionButtons from "@/components/Cabinet/CabinetActionButtons";
@@ -6,21 +10,18 @@ import { useAdminStatus } from "@/hooks/useAdminStatus";
 import CabinetSVG from "@/icons/cabinet.svg?react";
 
 interface AdminCabinetInformationDisplayProps
-  extends CabinetInfo,
+  extends SelectedCabinetInfo,
     SelectedMultiCabinetsData {
   username: string | null;
   clickedReturnButton: () => void;
   clickedStateManagementButton: () => void;
   cancelButton: () => void;
-  expiredAt: string | null;
-  selectedStatus: string;
-  setSelectedStatus: (status: string) => void;
   selectedCabinet: SelectedCabinet | null;
-  setSelectedCabinet: (cabinet: SelectedCabinet | null) => void;
   setSelectedMultiCabinets: React.Dispatch<
     React.SetStateAction<StatusData[] | null>
   >;
   closeReturnModal: () => void;
+  setModalCancelState: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 const AdminCabinetInformationDisplay = ({
@@ -39,6 +40,7 @@ const AdminCabinetInformationDisplay = ({
   setSelectedStatus,
   setSelectedMultiCabinets,
   closeReturnModal,
+  setModalCancelState,
 }: AdminCabinetInformationDisplayProps) => {
   const { showsReturnButton, showsStatusManagementButton } = useAdminStatus({
     selectedStatus,
@@ -49,7 +51,9 @@ const AdminCabinetInformationDisplay = ({
     setSelectedCabinet,
     setSelectedMultiCabinets,
     closeReturnModal,
+    setModalCancelState,
   });
+
   return (
     <>
       <div className="text-center w-[17rem]">

--- a/src/components/Admin/Cabinet/AdminCabinetInformationDisplay.tsx
+++ b/src/components/Admin/Cabinet/AdminCabinetInformationDisplay.tsx
@@ -1,4 +1,4 @@
-import { CabinetInfo } from "@/types/CabinetType";
+import { CabinetInfo, SelectedCabinet, StatusData } from "@/types/CabinetType";
 import { SelectedMultiCabinetsData } from "@/types/MultiCabinetType";
 import { formatDate } from "@/utils/formatDate";
 import CabinetActionButtons from "@/components/Cabinet/CabinetActionButtons";
@@ -14,6 +14,13 @@ interface AdminCabinetInformationDisplayProps
   cancelButton: () => void;
   expiredAt: string | null;
   selectedStatus: string;
+  setSelectedStatus: (status: string) => void;
+  selectedCabinet: SelectedCabinet | null;
+  setSelectedCabinet: (cabinet: SelectedCabinet | null) => void;
+  setSelectedMultiCabinets: React.Dispatch<
+    React.SetStateAction<StatusData[] | null>
+  >;
+  closeReturnModal: () => void;
 }
 
 const AdminCabinetInformationDisplay = ({
@@ -28,11 +35,20 @@ const AdminCabinetInformationDisplay = ({
   clickedStateManagementButton,
   cancelButton,
   selectedStatus,
+  setSelectedCabinet,
+  setSelectedStatus,
+  setSelectedMultiCabinets,
+  closeReturnModal,
 }: AdminCabinetInformationDisplayProps) => {
   const { showsReturnButton, showsStatusManagementButton } = useAdminStatus({
+    selectedStatus,
+    setSelectedStatus,
+    selectedCabinet,
     isMultiButtonActive,
     selectedMultiCabinets,
-    selectedStatus,
+    setSelectedCabinet,
+    setSelectedMultiCabinets,
+    closeReturnModal,
   });
   return (
     <>

--- a/src/components/Admin/Cabinet/AdminCabinetLayout.tsx
+++ b/src/components/Admin/Cabinet/AdminCabinetLayout.tsx
@@ -39,7 +39,7 @@ const AdminCabinetLayout = ({
   isMyCabinet,
 }: AdminCabinetLayoutProps) => {
   const { getStatusColor } = useCabinet();
-  const { cabinetData, loading, fetchCabinetData } = useCabinetActivation({
+  const { cabinetData, isLoading, fetchCabinetData } = useCabinetActivation({
     selectedBuilding,
     selectedFloor,
     isMyCabinet,
@@ -147,7 +147,7 @@ const AdminCabinetLayout = ({
       </div>
 
       <div className="h-[74%] flex items-center justify-center">
-        {loading ? (
+        {isLoading ? (
           <CabinetButtonSkeleton />
         ) : (
           <div className="relative h-[30rem] overflow-scroll lg:w-[67rem] md:w-[80%] sm:w-[75%] w-[100%] z-10">

--- a/src/components/Admin/Cabinet/AdminCabinetLayout.tsx
+++ b/src/components/Admin/Cabinet/AdminCabinetLayout.tsx
@@ -65,7 +65,6 @@ const AdminCabinetLayout = ({
       id,
       status,
     };
-
     if (!isMultiButtonActive) {
       setSelectedMultiCabinets([selectedMultiCabinet]);
       return;
@@ -110,8 +109,10 @@ const AdminCabinetLayout = ({
 
   // Return, status 변경 시 cabinetCallApi 호출
   useEffect(() => {
-    if (selectedBuilding !== null && selectedFloor !== null) {
-      fetchCabinetData(selectedBuilding, selectedFloor);
+    if (location.pathname.startsWith("/admin")) {
+      if (selectedBuilding !== null && selectedFloor !== null) {
+        fetchCabinetData(selectedBuilding, selectedFloor);
+      }
     }
   }, [selectedBuilding, selectedFloor, selectedStatus]);
 

--- a/src/components/Admin/Cabinet/AdminSelectedCabinetInformation.tsx
+++ b/src/components/Admin/Cabinet/AdminSelectedCabinetInformation.tsx
@@ -123,6 +123,8 @@ const AdminSelectedCabinetInformation = ({
                 selectedCabinet={selectedCabinet}
                 selectedMultiCabinets={selectedMultiCabinets}
                 isMultiButtonActive={isMultiButtonActive}
+                setSelectedCabinet={setSelectedCabinet}
+                setSelectedMultiCabinets={setSelectedMultiCabinets}
               />
             )}
         </>

--- a/src/components/Admin/Cabinet/AdminSelectedCabinetInformation.tsx
+++ b/src/components/Admin/Cabinet/AdminSelectedCabinetInformation.tsx
@@ -1,4 +1,9 @@
-import { SelectedCabinetInfo, StatusData } from "@/types/CabinetType";
+import { SetStateAction } from "react";
+import {
+  SelectedCabinet,
+  SelectedCabinetInfo,
+  StatusData,
+} from "@/types/CabinetType";
 import { SelectedMultiCabinetsData } from "@/types/MultiCabinetType";
 import AdminCabinetInformationDisplay from "@/components/Admin/Cabinet/AdminCabinetInformationDisplay";
 import AdminStateManagementModal from "@/components/Admin/Cabinet/AdminStateManagementModal";
@@ -66,9 +71,14 @@ const AdminSelectedCabinetInformation = ({
     setSelectedMultiCabinets,
   });
   const { showsReturnButton, showsStatusManagementButton } = useAdminStatus({
+    selectedStatus,
+    setSelectedStatus,
+    selectedCabinet,
     isMultiButtonActive,
     selectedMultiCabinets,
-    selectedStatus,
+    setSelectedCabinet,
+    setSelectedMultiCabinets,
+    closeReturnModal,
   });
 
   const cabinetNumbersSort =
@@ -99,6 +109,10 @@ const AdminSelectedCabinetInformation = ({
             username={username}
             expiredAt={expiredAt}
             selectedStatus={selectedStatus}
+            closeReturnModal={closeReturnModal}
+            setSelectedStatus={setSelectedStatus}
+            setSelectedCabinet={setSelectedCabinet}
+            setSelectedMultiCabinets={setSelectedMultiCabinets}
           />
           {showsReturnButton && openReturnModal && (
             <ConfirmModalView
@@ -125,6 +139,7 @@ const AdminSelectedCabinetInformation = ({
                 isMultiButtonActive={isMultiButtonActive}
                 setSelectedCabinet={setSelectedCabinet}
                 setSelectedMultiCabinets={setSelectedMultiCabinets}
+                closeReturnModal={closeReturnModal}
               />
             )}
         </>

--- a/src/components/Admin/Cabinet/AdminSelectedCabinetInformation.tsx
+++ b/src/components/Admin/Cabinet/AdminSelectedCabinetInformation.tsx
@@ -1,9 +1,4 @@
-import { SetStateAction } from "react";
-import {
-  SelectedCabinet,
-  SelectedCabinetInfo,
-  StatusData,
-} from "@/types/CabinetType";
+import { SelectedCabinetInfo, StatusData } from "@/types/CabinetType";
 import { SelectedMultiCabinetsData } from "@/types/MultiCabinetType";
 import AdminCabinetInformationDisplay from "@/components/Admin/Cabinet/AdminCabinetInformationDisplay";
 import AdminStateManagementModal from "@/components/Admin/Cabinet/AdminStateManagementModal";
@@ -22,6 +17,7 @@ interface AdminSelectedCabinetInformationProps
   setSelectedMultiCabinets: React.Dispatch<
     React.SetStateAction<StatusData[] | null>
   >;
+  setModalCancelState: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 const AdminSelectedCabinetInformation = ({
@@ -36,6 +32,7 @@ const AdminSelectedCabinetInformation = ({
   isMultiButtonActive,
   username,
   setSelectedMultiCabinets,
+  setModalCancelState,
 }: AdminSelectedCabinetInformationProps) => {
   const { openReturnModal, setOpenReturnModal } = useConfirmModalState();
   const { openStateManagementModal, setOpenStateManagementModal } =
@@ -79,6 +76,7 @@ const AdminSelectedCabinetInformation = ({
     setSelectedCabinet,
     setSelectedMultiCabinets,
     closeReturnModal,
+    setModalCancelState,
   });
 
   const cabinetNumbersSort =
@@ -113,6 +111,7 @@ const AdminSelectedCabinetInformation = ({
             setSelectedStatus={setSelectedStatus}
             setSelectedCabinet={setSelectedCabinet}
             setSelectedMultiCabinets={setSelectedMultiCabinets}
+            setModalCancelState={setOpenStateManagementModal}
           />
           {showsReturnButton && openReturnModal && (
             <ConfirmModalView

--- a/src/components/Admin/Cabinet/AdminStateManagementModal.tsx
+++ b/src/components/Admin/Cabinet/AdminStateManagementModal.tsx
@@ -37,14 +37,14 @@ const AdminStateManagementModal = ({
   closeReturnModal,
 }: HandleModalProps) => {
   const {
+    canSelectedReasonButton,
     selectedBrokenReason,
     newStatus,
     setNewStatus,
     getStatusLabel,
     getMultiCabinetStatusLabel,
+    handleStatusSave,
     handleReasonClick,
-    fetchAdminChangeStatus,
-    canSelectedReasonButton,
   } = useAdminStatus({
     selectedStatus,
     setSelectedStatus,
@@ -54,6 +54,7 @@ const AdminStateManagementModal = ({
     setSelectedCabinet,
     setSelectedMultiCabinets,
     closeReturnModal,
+    setModalCancelState,
   });
   const { isDropdownOpen, setIsDropdownOpen, dropdownOutsideRef } =
     useBuildingState();
@@ -65,21 +66,8 @@ const AdminStateManagementModal = ({
 
   // 상태관리 함수
   const handleMultiStatusChange = (status: CabinetStatusType) => {
-    setSelectedMultiCabinets(
-      (prevSelectedCabinets) =>
-        prevSelectedCabinets?.map((cabinet) => ({ ...cabinet, status })) ?? [],
-    );
     setNewStatus(status);
     setIsDropdownOpen(false);
-  };
-
-  // 상태 저장
-  const handleStatusSave = (
-    newStatus: CabinetStatusType,
-    reason: string | null,
-  ) => {
-    fetchAdminChangeStatus(newStatus, reason);
-    setModalCancelState(false); // fetch 함수로 이동해야 함
   };
 
   return (
@@ -103,7 +91,6 @@ const AdminStateManagementModal = ({
                     : !newStatus
                       ? getMultiCabinetStatusLabel()
                       : getStatusLabel(newStatus)}
-
                   <AngleDownSVG className="ml-[70%]" fill="#2563eb" />
                 </button>
 
@@ -174,7 +161,6 @@ const AdminStateManagementModal = ({
             className="px-4 py-2 bg-gray-200 text-gray-700 rounded-md hover:bg-gray-100"
             onClick={() => {
               setModalCancelState(false);
-              getMultiCabinetStatusLabel();
             }}
           >
             취소

--- a/src/components/Cabinet/CabinetButtonLayout.tsx
+++ b/src/components/Cabinet/CabinetButtonLayout.tsx
@@ -15,7 +15,7 @@ const CabinetButtonLayout = ({
   fetchCabinetDetailInformation,
 }: CabinetButtonLayoutProps) => {
   const { getStatusColor } = useCabinet();
-  const { cabinetData, loading } = useCabinetActivation({
+  const { cabinetData, isLoading } = useCabinetActivation({
     selectedBuilding,
     selectedFloor,
     isMyCabinet,
@@ -32,7 +32,7 @@ const CabinetButtonLayout = ({
 
   return (
     <div className="w-full h-[80%] flex items-center justify-center">
-      {loading ? (
+      {isLoading ? (
         <CabinetButtonSkeleton />
       ) : (
         <div className="relative h-[30rem] overflow-scroll lg:w-[67rem] md:w-[80%] sm:w-[75%] w-[100%]">

--- a/src/components/Cabinet/SelectedCabinetInformation.tsx
+++ b/src/components/Cabinet/SelectedCabinetInformation.tsx
@@ -130,7 +130,8 @@ const SelectedCabinetInformation = ({
               />
             )}
           </>
-        ) : selectedStatus === "USING" && isMyCabinet === false ? (
+        ) : (selectedStatus === "USING" && isMyCabinet === false) ||
+          selectedStatus === "OVERDUE" ? (
           // 상태가 USING이고 타인의 사물함일 경우
           <CabinetInformationDisplay
             selectedBuilding={selectedBuilding}
@@ -138,7 +139,7 @@ const SelectedCabinetInformation = ({
             selectedCabinet={selectedCabinet}
             statusMessage="이미 대여중인 사물함입니다."
           />
-        ) : selectedStatus === "BROKEN" || selectedStatus === "OVERDUE" ? (
+        ) : selectedStatus === "BROKEN" ? (
           <CabinetInformationDisplay
             selectedBuilding={selectedBuilding}
             selectedFloor={selectedFloor}

--- a/src/hooks/useAdminStatus.tsx
+++ b/src/hooks/useAdminStatus.tsx
@@ -1,50 +1,177 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { SelectedCabinet, StatusData } from "@/types/CabinetType";
 import { SelectedMultiCabinetsData } from "@/types/MultiCabinetType";
+import { CabinetStatus, CabinetStatusType } from "@/types/StatusEnum";
+import { log } from "@/utils/logger";
+import { adminChangeStatusApi } from "@/api/adminChangeStatusApi";
+import { useAdminReturn } from "./useAdminReturn";
 
 interface useAdminStatusProps extends SelectedMultiCabinetsData {
   selectedStatus: string;
+  setSelectedStatus: (status: string) => void;
+  selectedCabinet: SelectedCabinet | null;
+  setSelectedCabinet: (cabinet: SelectedCabinet | null) => void;
+  setSelectedMultiCabinets: React.Dispatch<
+    React.SetStateAction<StatusData[] | null>
+  >;
+  closeReturnModal: () => void;
 }
 
 export const useAdminStatus = ({
+  selectedStatus,
+  setSelectedStatus,
+  selectedCabinet,
   isMultiButtonActive,
   selectedMultiCabinets,
-  selectedStatus,
+  setSelectedCabinet,
+  setSelectedMultiCabinets,
+  closeReturnModal,
 }: useAdminStatusProps) => {
   const [selectedBrokenReason, setSelectedBrokenReason] = useState<
     string | null
-  >(null); // 고장 이유 선택
+  >(null);
+  const [newStatus, setNewStatus] = useState<string>();
 
-  const handleReasonClick = (reason: string) => {
-    setSelectedBrokenReason(reason);
-  };
+  const { fetchAdminCabinetReturn } = useAdminReturn({
+    selectedCabinet,
+    selectedMultiCabinets,
+    closeReturnModal,
+    selectedStatus,
+    setSelectedStatus,
+    isMultiButtonActive,
+    setSelectedCabinet,
+    setSelectedMultiCabinets,
+  });
 
+  // 반납, 상태관리 버튼과 관련된 조건
   // status 추가 시 아래 STATUS_CATEGORIES에 추가
   const STATUS_CATEGORIES = {
-    returnable: ["USING", "OVERDUE"],
-    manageable: ["AVAILABLE", "BROKEN"],
+    returnable: [CabinetStatus.USING, CabinetStatus.OVERDUE],
+    manageable: [CabinetStatus.AVAILABLE, CabinetStatus.BROKEN],
+    available: [
+      CabinetStatus.AVAILABLE,
+      CabinetStatus.USING,
+      CabinetStatus.OVERDUE,
+    ],
+    breakable: [CabinetStatus.BROKEN],
   };
 
-  const hasStatus = (category: string[], status: string) =>
+  const hasStatus = (category: string[]) =>
     isMultiButtonActive
       ? selectedMultiCabinets?.some((cabinet) =>
           category.includes(cabinet.status),
-        ) || false
-      : category.includes(status);
+        )
+      : category.includes(selectedStatus);
 
-  const showsReturnButton = hasStatus(
-    STATUS_CATEGORIES.returnable,
-    selectedStatus,
-  );
-  const showsStatusManagementButton = hasStatus(
-    STATUS_CATEGORIES.manageable,
-    selectedStatus,
-  );
+  const showsReturnButton = hasStatus(STATUS_CATEGORIES.returnable);
+  const showsStatusManagementButton = hasStatus(STATUS_CATEGORIES.manageable);
+  const hasAvailable = hasStatus(STATUS_CATEGORIES.available);
+  const hasBroken = hasStatus(STATUS_CATEGORIES.breakable);
+
+  // 사용 가능, 사용 불가 버튼과 관련된 조건
+  const isBroken = selectedStatus === CabinetStatus.BROKEN;
+  const isAvailable = selectedStatus === CabinetStatus.AVAILABLE;
+  // 아 마지막에 선택된 사물함이 using이 아니라서 실행이 안되는 거엿음! -> 수정하기
+  const isUsing = selectedStatus === CabinetStatus.USING;
+  const isOverdue = selectedStatus === CabinetStatus.OVERDUE;
+  const isNewStatusBroken = newStatus === CabinetStatus.BROKEN;
+  const isNewStatusAvailable = newStatus === CabinetStatus.AVAILABLE;
+
+  // Reason 버튼 활성화 조건 (사용 가능 -> 비활성화, 사용 불가 -> 활성화)
+  const canSelectedReasonButton =
+    (!hasAvailable && isNewStatusBroken) || isNewStatusBroken;
+
+  // 상태관리 API 호출
+  const fetchAdminChangeStatus = async (
+    newStatus: CabinetStatusType,
+    reason: string | null,
+  ) => {
+    const cabinetIds: number[] = isMultiButtonActive
+      ? (selectedMultiCabinets?.map((cabinet) => cabinet.id) ?? [])
+      : selectedCabinet
+        ? [selectedCabinet.cabinetId]
+        : [];
+
+    const test = hasStatus(STATUS_CATEGORIES.returnable);
+
+    if (test) {
+      await fetchAdminCabinetReturn();
+      console.log("너 뭐야", test);
+    }
+
+    // using -> 나머지: 실행 XXXXX
+    setNewStatus(selectedStatus);
+    try {
+      const response = await adminChangeStatusApi(
+        cabinetIds,
+        newStatus,
+        reason,
+      );
+      if (response) {
+        setSelectedStatus(response.data.cabinets.status);
+        setSelectedBrokenReason(response.data.cabinets.reason);
+        setSelectedMultiCabinets(null);
+        setSelectedCabinet(null);
+        console.log(response.data);
+        log.info(
+          `API 호출 성공: adminChangeStatusApi, ${JSON.stringify(response, null, 2)}`,
+        );
+
+        return response.data;
+      }
+    } catch (error) {
+      log.error("API 호출 중 에러 발생: adminChangeStatusApi");
+    }
+  };
+
+  // 사물함 단일 선택
+  const getStatusLabel = (status?: string) => {
+    return status === CabinetStatus.BROKEN ? "사용 불가" : "사용 가능";
+  };
+
+  // 사물함 복수 선택
+  const getMultiCabinetStatusLabel = () => {
+    if (isMultiButtonActive) {
+      if (isNewStatusAvailable) return "사용 가능";
+      if (isNewStatusBroken) return "사용 불가";
+    }
+    if (isAvailable || isBroken || isUsing || isOverdue) return "상태 선택";
+  };
+
+  // 고장 이유 선택
+  const handleReasonClick = (reason: string | null) => {
+    setSelectedBrokenReason(reason);
+  };
+
+  // 상태 저장
+  const handleStatusSave = (
+    newStatus: CabinetStatusType,
+    reason: string | null,
+  ) => {
+    fetchAdminChangeStatus(newStatus, reason);
+  };
+
+  useEffect(() => {
+    if (newStatus !== CabinetStatus.BROKEN) {
+      setSelectedBrokenReason(null); // 선택 취소
+    }
+  }, [newStatus]); // newStatus 변경될 때 실행
 
   return {
-    selectedBrokenReason,
-    setSelectedBrokenReason,
-    handleReasonClick,
     showsReturnButton,
     showsStatusManagementButton,
+    isBroken,
+    isNewStatusAvailable,
+    isNewStatusBroken,
+    canSelectedReasonButton,
+    selectedBrokenReason,
+    setSelectedBrokenReason,
+    newStatus,
+    setNewStatus,
+    fetchAdminChangeStatus,
+    getStatusLabel,
+    getMultiCabinetStatusLabel,
+    handleStatusSave,
+    handleReasonClick,
   };
 };

--- a/src/hooks/useAdminStatus.tsx
+++ b/src/hooks/useAdminStatus.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { SelectedMultiCabinetsData } from "@/types/MultiCabinetType";
 
-interface testProps extends SelectedMultiCabinetsData {
+interface useAdminStatusProps extends SelectedMultiCabinetsData {
   selectedStatus: string;
 }
 
@@ -9,7 +9,7 @@ export const useAdminStatus = ({
   isMultiButtonActive,
   selectedMultiCabinets,
   selectedStatus,
-}: testProps) => {
+}: useAdminStatusProps) => {
   const [selectedBrokenReason, setSelectedBrokenReason] = useState<
     string | null
   >(null); // 고장 이유 선택

--- a/src/hooks/useCabinet.tsx
+++ b/src/hooks/useCabinet.tsx
@@ -1,5 +1,4 @@
 import { useRef, useState } from "react";
-
 import { SelectedCabinet } from "@/types/CabinetType";
 import { log } from "@/utils/logger";
 import { cabinetDetailInfoApi } from "@/api/cabinetDetailInfoApi";
@@ -18,8 +17,9 @@ export const useCabinet = () => {
     cabinetId: number,
     cabinetNumber: number,
   ) => {
-    if (prevCabinetNumberRef.current === cabinetNumber) return;
-
+    if (selectedCabinet !== null) {
+      if (prevCabinetNumberRef.current === cabinetNumber) return;
+    }
     try {
       const response = await cabinetDetailInfoApi(cabinetId);
       prevCabinetNumberRef.current = cabinetNumber;

--- a/src/hooks/useCabinetActivation.tsx
+++ b/src/hooks/useCabinetActivation.tsx
@@ -33,8 +33,10 @@ export const useCabinetActivation = ({
     }
   };
   useEffect(() => {
-    if (selectedBuilding !== null && selectedFloor !== null) {
-      fetchCabinetData(selectedBuilding, selectedFloor);
+    if (location.pathname.startsWith("/main")) {
+      if (selectedBuilding !== null && selectedFloor !== null) {
+        fetchCabinetData(selectedBuilding, selectedFloor);
+      }
     }
   }, [selectedBuilding, selectedFloor, isMyCabinet]);
 

--- a/src/hooks/useCabinetActivation.tsx
+++ b/src/hooks/useCabinetActivation.tsx
@@ -14,12 +14,12 @@ export const useCabinetActivation = ({
   isMyCabinet,
 }: UseCabinetActivationProps) => {
   const [cabinetData, setCabinetData] = useState<CabinetData[]>([]);
-  const [loading, setLoading] = useState<boolean>(true);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
 
   // 사물함 API 호출
   const fetchCabinetData = async (building: string, floor: number) => {
     try {
-      setLoading(true);
+      setIsLoading(true);
       const response = await cabinetCallApi(building, floor);
       setCabinetData(response.cabinets);
       log.info(
@@ -29,7 +29,7 @@ export const useCabinetActivation = ({
     } catch (error) {
       log.error("API 호출 중 에러 발생: cabinetCallApi");
     } finally {
-      setLoading(false);
+      setIsLoading(false);
     }
   };
   useEffect(() => {
@@ -44,6 +44,6 @@ export const useCabinetActivation = ({
     cabinetData,
     setCabinetData,
     fetchCabinetData,
-    loading,
+    isLoading,
   };
 };

--- a/src/pages/Admin/AdminMainPage.tsx
+++ b/src/pages/Admin/AdminMainPage.tsx
@@ -32,6 +32,7 @@ const AdminMainPage = () => {
     setSelectedMultiCabinets,
     isMultiButtonActive,
     setIsMultiButtonActive,
+    setOpenStateManagementModal,
   } = useAdminCabinet();
 
   useEffect(() => {
@@ -106,6 +107,7 @@ const AdminMainPage = () => {
               isMultiButtonActive={isMultiButtonActive}
               username={username}
               setSelectedMultiCabinets={setSelectedMultiCabinets}
+              setModalCancelState={setOpenStateManagementModal}
             />
           </div>
         )}
@@ -179,6 +181,7 @@ const AdminMainPage = () => {
               isMultiButtonActive={isMultiButtonActive}
               username={username}
               setSelectedMultiCabinets={setSelectedMultiCabinets}
+              setModalCancelState={setOpenStateManagementModal}
             />
           </div>
         )}

--- a/src/types/StatusEnum.ts
+++ b/src/types/StatusEnum.ts
@@ -7,3 +7,9 @@ export const CabinetStatus = {
 
 export type CabinetStatusType =
   (typeof CabinetStatus)[keyof typeof CabinetStatus];
+
+export const BrokenReason = {
+  잠금: "잠금",
+  파손: "파손",
+} as const;
+export type BrokenReasonType = (typeof BrokenReason)[keyof typeof BrokenReason];


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #83 

## 📝작업 내용

> 상태관리 API 연동
> - 단일/복수 선택 모두 `'상태 선택'`을 통해 status 선택 (+reason 선택)하도록 구현하였습니다.
> -`'사용가능'`은 reason 버튼을 비활성화하였고, `'사용불가'`는 reason 버튼을 활성화하였습니다.
> - `대여중인 사물함`이 `'사용불가'`로 바뀔 때 반납이 되도록 구현하였습니다.
>       - (단일 선택에는 문제가 없는데, 복수 선택 시 마지막 버튼의 Status가 `using` or `overdue`가 아니면 반납 처리가 안되는 오류가 있습니다.. 계속 해결해보겠습니다..)  
>       - `'사용 가능'`일 때는 단일/복수 선택 관계없이 반납처리가 됩니다

### 스크린샷 (선택)

https://github.com/user-attachments/assets/c1fcbe9c-3e16-494a-a075-606f55f88f95


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
