### PR TITLE
Fix: Admin 전체 선택시 사물함 정보가 바로 보이도록 수정

### DIFF
--- a/src/components/Admin/Cabinet/AdminAllSelectButton.tsx
+++ b/src/components/Admin/Cabinet/AdminAllSelectButton.tsx
@@ -26,7 +26,7 @@ const AdminAllSelectButton = React.memo(
           className={`flex-row mr-1 w-4 h-4 appearance-none border rounded-sm bg-no-repeat bg-center
             ${
               isMultiButtonActive
-                ? `border-blue-600 checked:bg-blue-600 checked:border-0 ${
+                ? `border-blue-600 ${
                     selectedMultiCabinets?.length === cabinetData.length
                       ? "bg-[url('./icons/check.svg')] bg-blue-600"
                       : selectedMultiCabinets?.length &&

--- a/src/components/Admin/Cabinet/AdminCabinetLayout.tsx
+++ b/src/components/Admin/Cabinet/AdminCabinetLayout.tsx
@@ -1,7 +1,7 @@
 // 사물함 배열 관련
 import { useCallback, useEffect } from "react";
 import {
-  CabinetLayout,
+  CabinetButtonLayoutProps,
   SelectedCabinet,
   StatusData,
 } from "@/types/CabinetType";
@@ -15,7 +15,7 @@ import { useCabinet } from "@/hooks/useCabinet";
 import { useCabinetActivation } from "@/hooks/useCabinetActivation";
 
 interface AdminCabinetLayoutProps
-  extends CabinetLayout,
+  extends CabinetButtonLayoutProps,
     SelectedMultiCabinetsData {
   selectedStatus: string;
   setSelectedMultiCabinets: React.Dispatch<

--- a/src/components/Admin/Cabinet/AdminCabinetLayout.tsx
+++ b/src/components/Admin/Cabinet/AdminCabinetLayout.tsx
@@ -23,6 +23,7 @@ interface AdminCabinetLayoutProps
   >;
   setIsMultiButtonActive: (value: boolean) => void;
   setSelectedCabinet: (cabinet: SelectedCabinet | null) => void;
+  setIsAdminCabinetInfoVisible: (value: boolean) => void;
 }
 
 const AdminCabinetLayout = ({
@@ -37,6 +38,7 @@ const AdminCabinetLayout = ({
   setSelectedCabinet,
   selectedStatus,
   isMyCabinet,
+  setIsAdminCabinetInfoVisible,
 }: AdminCabinetLayoutProps) => {
   const { getStatusColor } = useCabinet();
   const { cabinetData, isLoading, fetchCabinetData } = useCabinetActivation({
@@ -45,6 +47,7 @@ const AdminCabinetLayout = ({
     isMyCabinet,
   });
   const { checkedCabinet, setCheckedCabinet } = useAdminCabinet();
+  const MAX_CABINETS = 47; // Cabinet 배열의 최대 길이
 
   // 복수선택기능 버튼 활성화
   const MultipleSelectButtonActive = useCallback(() => {
@@ -87,6 +90,7 @@ const AdminCabinetLayout = ({
   const handleSelectAllCabinets = () => {
     if (checkedCabinet) {
       setSelectedMultiCabinets(null);
+      setIsAdminCabinetInfoVisible(false); // 전체 해제 시 사물함 정보 숨김
     } else {
       setSelectedMultiCabinets(
         cabinetData.map((cabinet) => ({
@@ -95,12 +99,13 @@ const AdminCabinetLayout = ({
           status: cabinet.status,
         })),
       );
+      setIsAdminCabinetInfoVisible(true); // 전체 선택 시 사물함 정보 표시
     }
     setCheckedCabinet(!checkedCabinet);
   };
 
   useEffect(() => {
-    setSelectedMultiCabinets(null);
+    setSelectedMultiCabinets([]);
     setSelectedCabinet(null);
     if (!isMultiButtonActive) {
       setCheckedCabinet(false);
@@ -113,8 +118,18 @@ const AdminCabinetLayout = ({
       if (selectedBuilding !== null && selectedFloor !== null) {
         fetchCabinetData(selectedBuilding, selectedFloor);
       }
+      if (selectedMultiCabinets === null) {
+        setCheckedCabinet(false); // 전체 선택 해제
+      }
     }
-  }, [selectedBuilding, selectedFloor, selectedStatus]);
+  }, [
+    selectedBuilding,
+    selectedFloor,
+    selectedStatus,
+    checkedCabinet &&
+      selectedMultiCabinets &&
+      selectedMultiCabinets.length === MAX_CABINETS, // 전체선택
+  ]);
 
   // 검색 결과에 해당하는 사물함이 있을 경우에만 실행
   useEffect(() => {

--- a/src/components/Admin/Cabinet/AdminSelectedCabinetInformation.tsx
+++ b/src/components/Admin/Cabinet/AdminSelectedCabinetInformation.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { SelectedCabinetInfo, StatusData } from "@/types/CabinetType";
 import { SelectedMultiCabinetsData } from "@/types/MultiCabinetType";
 import AdminCabinetInformationDisplay from "@/components/Admin/Cabinet/AdminCabinetInformationDisplay";
@@ -18,6 +19,9 @@ interface AdminSelectedCabinetInformationProps
     React.SetStateAction<StatusData[] | null>
   >;
   setModalCancelState: React.Dispatch<React.SetStateAction<boolean>>;
+  isAdminCabinetInfoVisible: boolean;
+  setIsAdminCabinetInfoVisible: (value: boolean) => void;
+  setCheckedCabinet: (value: boolean) => void;
 }
 
 const AdminSelectedCabinetInformation = ({
@@ -33,11 +37,13 @@ const AdminSelectedCabinetInformation = ({
   username,
   setSelectedMultiCabinets,
   setModalCancelState,
+  isAdminCabinetInfoVisible,
+  setIsAdminCabinetInfoVisible,
+  setCheckedCabinet,
 }: AdminSelectedCabinetInformationProps) => {
   const { openReturnModal, setOpenReturnModal } = useConfirmModalState();
   const { openStateManagementModal, setOpenStateManagementModal } =
     useAdminCabinet();
-
   // 반납 버튼 클릭 -> 반납 모달창 생성
   const clickedReturnButton = () => {
     setOpenReturnModal(true);
@@ -55,6 +61,8 @@ const AdminSelectedCabinetInformation = ({
   const cancelButton = () => {
     setSelectedCabinet(null);
     setSelectedMultiCabinets(null);
+    setCheckedCabinet(false);
+    setIsAdminCabinetInfoVisible(false);
   };
 
   const { fetchAdminCabinetReturn } = useAdminReturn({
@@ -92,8 +100,19 @@ const AdminSelectedCabinetInformation = ({
 
   return (
     <div className="absolute inset-y-0 right-0 w-80 pt-20 flex flex-col justify-center items-center bg-white border-l-2 border-gray-400">
-      {selectedCabinet !== null &&
-      (isMultiButtonActive ? selectedMultiCabinets?.length : true) ? (
+      {(!isMultiButtonActive && selectedCabinet === null) ||
+      (isMultiButtonActive && selectedMultiCabinets?.length === 0) ||
+      selectedMultiCabinets === null ? (
+        <>
+          <div className="flex justify-center pb-5">
+            <CabinetSVG />
+          </div>
+          사물함을
+          <br />
+          선택해주세요
+        </>
+      ) : (isMultiButtonActive && isAdminCabinetInfoVisible) ||
+        selectedCabinet !== null ? (
         <>
           <AdminCabinetInformationDisplay
             selectedBuilding={selectedBuilding}
@@ -142,16 +161,7 @@ const AdminSelectedCabinetInformation = ({
               />
             )}
         </>
-      ) : (
-        <>
-          <div className="flex justify-center pb-5">
-            <CabinetSVG />
-          </div>
-          사물함을
-          <br />
-          선택해주세요
-        </>
-      )}
+      ) : null}
     </div>
   );
 };

--- a/src/components/Admin/Cabinet/AdminStateManagementModal.tsx
+++ b/src/components/Admin/Cabinet/AdminStateManagementModal.tsx
@@ -16,7 +16,7 @@ interface HandleModalProps extends SelectedMultiCabinetsData {
   selectedStatus: string;
   setSelectedStatus: (status: string) => void;
   cabinetInfo?: string;
-  selectedCabinet: SelectedCabinet;
+  selectedCabinet: SelectedCabinet | null;
   setSelectedCabinet: (cabinet: SelectedCabinet | null) => void;
   setSelectedMultiCabinets: React.Dispatch<
     React.SetStateAction<StatusData[] | null>

--- a/src/hooks/useAdminCabinet.tsx
+++ b/src/hooks/useAdminCabinet.tsx
@@ -10,6 +10,8 @@ export const useAdminCabinet = () => {
   const [openStateManagementModal, setOpenStateManagementModal] =
     useState(false); // 상태관리 모달
   const [checkedCabinet, setCheckedCabinet] = useState(false); // 전체선택 여부 나타내는 변수
+  const [isAdminCabinetInfoVisible, setIsAdminCabinetInfoVisible] =
+    useState(false); // 전체 선택 시 사물함 정보 바로 보이게 하는 변수
 
   return {
     selectedMultiCabinets,
@@ -20,5 +22,7 @@ export const useAdminCabinet = () => {
     setOpenStateManagementModal,
     checkedCabinet,
     setCheckedCabinet,
+    isAdminCabinetInfoVisible,
+    setIsAdminCabinetInfoVisible,
   };
 };

--- a/src/hooks/useAdminStatus.tsx
+++ b/src/hooks/useAdminStatus.tsx
@@ -134,7 +134,8 @@ export const useAdminStatus = ({
       if (isNewStatusAvailable) return "사용 가능";
       if (isNewStatusBroken) return "사용 불가";
     }
-    if (isAllStatus) return "상태 선택";
+    if (isAllStatus || selectedMultiCabinets?.length !== null)
+      return "상태 선택";
   };
 
   // 고장 이유 선택

--- a/src/pages/Admin/AdminMainPage.tsx
+++ b/src/pages/Admin/AdminMainPage.tsx
@@ -33,6 +33,9 @@ const AdminMainPage = () => {
     isMultiButtonActive,
     setIsMultiButtonActive,
     setOpenStateManagementModal,
+    isAdminCabinetInfoVisible,
+    setIsAdminCabinetInfoVisible,
+    setCheckedCabinet,
   } = useAdminCabinet();
 
   useEffect(() => {
@@ -82,6 +85,7 @@ const AdminMainPage = () => {
                 setIsMultiButtonActive={setIsMultiButtonActive}
                 setSelectedCabinet={setSelectedCabinet}
                 isMyCabinet={isMyCabinet as boolean}
+                setIsAdminCabinetInfoVisible={setIsAdminCabinetInfoVisible}
               />
             </>
           )}
@@ -108,6 +112,9 @@ const AdminMainPage = () => {
               username={username}
               setSelectedMultiCabinets={setSelectedMultiCabinets}
               setModalCancelState={setOpenStateManagementModal}
+              isAdminCabinetInfoVisible={isAdminCabinetInfoVisible}
+              setIsAdminCabinetInfoVisible={setIsAdminCabinetInfoVisible}
+              setCheckedCabinet={setCheckedCabinet}
             />
           </div>
         )}
@@ -156,6 +163,7 @@ const AdminMainPage = () => {
                   setIsMultiButtonActive={setIsMultiButtonActive}
                   setSelectedCabinet={setSelectedCabinet}
                   isMyCabinet={isMyCabinet as boolean}
+                  setIsAdminCabinetInfoVisible={setIsAdminCabinetInfoVisible}
                 />
               </div>
             </>
@@ -182,6 +190,9 @@ const AdminMainPage = () => {
               username={username}
               setSelectedMultiCabinets={setSelectedMultiCabinets}
               setModalCancelState={setOpenStateManagementModal}
+              isAdminCabinetInfoVisible={isAdminCabinetInfoVisible}
+              setIsAdminCabinetInfoVisible={setIsAdminCabinetInfoVisible}
+              setCheckedCabinet={setCheckedCabinet}
             />
           </div>
         )}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) 

## 📝작업 내용

> 기존에는 하나의 사물함을 무조건 선택해야 전체 선택을 하더라도 모든 사물함 정보가 보였는데, 이 문제를 전체선택 checkbox를 선택만 하더라도 모든 사물함 정보가 보일 수 있도록 수정하였습니다

### 스크린샷 (선택)

https://github.com/user-attachments/assets/423bba15-09a9-4111-b7b0-f1316bbd4faf


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
