### PR TITLE
Fix, Refactor : 토큰 인증 로직 개선 및 권한 없는 사용자 URL 리다이렉트 방지 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "lodash": "^4.17.21",
         "lodash-es": "^4.17.21",
         "react": "^18.3.1",
+        "react-cookie": "^8.0.1",
         "react-dom": "^18.3.1",
         "react-redux": "^9.1.2",
         "react-router": "^6.26.2",
@@ -3295,6 +3296,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.6.tgz",
+      "integrity": "sha512-lPByRJUer/iN/xa4qpyL0qmL11DqNW81iU/IG1S3uvRUq4oKagz8VCxZjiWkumgt66YT3vOdDgZ0o32sGKtCEw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -3322,14 +3333,12 @@
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
       "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
       "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -4036,6 +4045,15 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/core-js-compat": {
       "version": "3.40.0",
@@ -5131,6 +5149,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -6097,6 +6130,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-cookie": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-8.0.1.tgz",
+      "integrity": "sha512-QNdAd0MLuAiDiLcDU/2s/eyKmmfMHtjPUKJ2dZ/5CcQ9QKUium4B3o61/haq6PQl/YWFqC5PO8GvxeHKhy3GFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.3.6",
+        "hoist-non-react-statics": "^3.3.2",
+        "universal-cookie": "^8.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -6984,6 +7031,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/universal-cookie": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-8.0.1.tgz",
+      "integrity": "sha512-B6ks9FLLnP1UbPPcveOidfvB9pHjP+wekP2uRYB9YDfKVpvcjKgy1W5Zj+cEXJ9KTPnqOKGfVDQBmn8/YCQfRg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.2"
       }
     },
     "node_modules/update-browserslist-db": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lodash": "^4.17.21",
     "lodash-es": "^4.17.21",
     "react": "^18.3.1",
+    "react-cookie": "^8.0.1",
     "react-dom": "^18.3.1",
     "react-redux": "^9.1.2",
     "react-router": "^6.26.2",

--- a/src/api/axiosInterceptApi.tsx
+++ b/src/api/axiosInterceptApi.tsx
@@ -24,6 +24,7 @@ api.interceptors.request.use(
     return response;
   },
   (error) => {
+    log.error(`요청 인터셉터 에러 ${error}`);
     return Promise.reject(error);
   },
 );
@@ -46,9 +47,10 @@ api.interceptors.response.use(
         const newAccessToken = response.data.accessToken;
 
         setCookie("accessToken", newAccessToken);
+        log.info("accessToken 재발급 성공");
         return api(Request);
       } catch (refreshError) {
-        console.error("refresh 토큰 만료", refreshError);
+        log.warn("refresh 토큰 만료");
         removeCookie("accessToken");
         window.location.href = "/login";
         return Promise.reject(refreshError);
@@ -57,13 +59,13 @@ api.interceptors.response.use(
       objectErrorStatus === 401 &&
       objectErrorTokenClass === `"RefreshToken"`
     ) {
-      console.error("refresh 토큰 만료", error);
+      log.warn("refresh 토큰 만료");
       removeCookie("accessToken");
       window.location.href = "/login";
       return Promise.reject(error);
     }
     if (objectErrorStatus === 500) {
-      console.error("500에러", error);
+      log.error("서버 에러 500");
       removeCookie("accessToken");
       window.location.href = "/login";
       return Promise.reject(error);

--- a/src/api/axiosInterceptApi.tsx
+++ b/src/api/axiosInterceptApi.tsx
@@ -1,4 +1,6 @@
 import axios from "axios";
+import { getCookie, removeCookie, setCookie } from "@/utils/cookies";
+import { log } from "@/utils/logger";
 
 const api = axios.create({
   baseURL: import.meta.env.VITE_BE_URL, // 모든 api 요청은 기본으로 localhost:8000 으로 보냅니다.
@@ -7,12 +9,17 @@ const api = axios.create({
 
 api.interceptors.request.use(
   (response) => {
-    const accessToken = document.cookie
-      .split("; ")
-      .find((cookie) => cookie.startsWith("accessToken="))
-      ?.split("=")[1];
+    const accessToken = getCookie("accessToken");
+
+    const currentPath = window.location.pathname;
+    const isLoginPage =
+      currentPath === "/login" || currentPath === "/admin/login";
     if (accessToken) {
       response.headers.Authorization = `Bearer ${accessToken}`;
+    }
+    if (!accessToken && !isLoginPage) {
+      log.error("accessToken이 존재하지 않습니다.");
+      window.location.href = "/login";
     }
     return response;
   },
@@ -37,11 +44,12 @@ api.interceptors.response.use(
       try {
         const response = await api.post("/authn/token/access");
         const newAccessToken = response.data.accessToken;
-        document.cookie = `accessToken=${newAccessToken}; path=/; Secure; SameSite=Strict`;
+
+        setCookie("accessToken", newAccessToken);
         return api(Request);
       } catch (refreshError) {
         console.error("refresh 토큰 만료", refreshError);
-        document.cookie = `accessToken=; path=/; Expires=Thu, 01 Jan 1970 00:00:00 UTC;`; // accessToken 만료로 삭제
+        removeCookie("accessToken");
         window.location.href = "/login";
         return Promise.reject(refreshError);
       }
@@ -50,13 +58,13 @@ api.interceptors.response.use(
       objectErrorTokenClass === `"RefreshToken"`
     ) {
       console.error("refresh 토큰 만료", error);
-      document.cookie = `accessToken=; path=/; Expires=Thu, 01 Jan 1970 00:00:00 UTC;`; // accessToken 만료로 삭제
+      removeCookie("accessToken");
       window.location.href = "/login";
       return Promise.reject(error);
     }
     if (objectErrorStatus === 500) {
       console.error("500에러", error);
-      document.cookie = `accessToken=; path=/; Expires=Thu, 01 Jan 1970 00:00:00 UTC;`; // accessToken 만료로 삭제
+      removeCookie("accessToken");
       window.location.href = "/login";
       return Promise.reject(error);
     }

--- a/src/hooks/useAuthRedirect.tsx
+++ b/src/hooks/useAuthRedirect.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from "react";
+import { useLocation, useNavigate } from "react-router";
+import { getCookie } from "@/utils/cookies";
+import { log } from "@/utils/logger";
+import { userDataApi } from "@/api/userDataApi";
+
+export const useAuthRedirect = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const token = getCookie("accessToken");
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+
+  // 같은 layout의 컴포넌트 끼리는 useEffect 가 실행되지않음
+  useEffect(() => {
+    const isAdmin = location.pathname.startsWith("/admin");
+    const loginPath = isAdmin ? "/admin/login" : "/login";
+    // 토큰의 유무를 판단
+    if (!token) {
+      navigate(loginPath);
+      setIsLoading(false);
+    } else {
+      // 위증된 토큰인지 확인하기위한 API 요청
+      (async () => {
+        try {
+          await userDataApi(); // 확인 용도라서 response값은 받지않음
+        } catch (error) {
+          log.error(`잘못된 토큰 정보로 URL Redirect ${error}`);
+          navigate(loginPath);
+        } finally {
+          setIsLoading(false);
+        }
+      })(); // 즉시 실행 함수 표현식 IIFE (() => {...})()
+    }
+  }, []);
+
+  return { isLoading };
+};

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,22 +1,20 @@
 import { Outlet } from "react-router";
 import { SideNavigationLayoutContext } from "@/contexts/SideNavigationLayoutContext";
 import SideNavigationLayout from "@/pages/SideNavigationLayout";
+import { useAuthRedirect } from "@/hooks/useAuthRedirect";
 import { useBuildingState } from "@/hooks/useBuildingState";
 
 const MainLayout = () => {
-  const {
-    buildingList,
-    selectedBuilding,
-    setSelectedBuilding,
-  } = useBuildingState();
-
+  const { buildingList, selectedBuilding, setSelectedBuilding } =
+    useBuildingState();
+  useAuthRedirect();
   return (
     <>
-      <SideNavigationLayoutContext.Provider 
-        value={{     
-          buildingList, 
-          selectedBuilding, 
-          setSelectedBuilding
+      <SideNavigationLayoutContext.Provider
+        value={{
+          buildingList,
+          selectedBuilding,
+          setSelectedBuilding,
         }}
       >
         {/* 상단 네비게이션 바 */}

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -7,7 +7,9 @@ import { useBuildingState } from "@/hooks/useBuildingState";
 const MainLayout = () => {
   const { buildingList, selectedBuilding, setSelectedBuilding } =
     useBuildingState();
-  useAuthRedirect();
+  const { isLoading } = useAuthRedirect();
+
+  if (isLoading) return <></>;
   return (
     <>
       <SideNavigationLayoutContext.Provider

--- a/src/utils/cookies.ts
+++ b/src/utils/cookies.ts
@@ -1,0 +1,12 @@
+import { Cookies } from "react-cookie";
+import { CookieSetOptions } from "universal-cookie";
+
+const cookies = new Cookies();
+
+export const getCookie = (name: string): string => {
+  return cookies.get<string>(name);
+};
+
+export const removeCookie = (name: string, option: CookieSetOptions): void => {
+  return cookies.remove(name, { ...option });
+};

--- a/src/utils/cookies.ts
+++ b/src/utils/cookies.ts
@@ -3,10 +3,21 @@ import { CookieSetOptions } from "universal-cookie";
 
 const cookies = new Cookies();
 
+export const setCookie = (
+  name: string,
+  value: string,
+  option: CookieSetOptions = { path: "/", secure: true, sameSite: "strict" },
+): void => {
+  return cookies.set(name, value, { ...option });
+};
+
 export const getCookie = (name: string): string => {
   return cookies.get<string>(name);
 };
 
-export const removeCookie = (name: string, option: CookieSetOptions): void => {
+export const removeCookie = (
+  name: string,
+  option: CookieSetOptions = { path: "/" },
+): void => {
   return cookies.remove(name, { ...option });
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #93 

## 📝작업 내용

> url 리다이렉팅시 권한없는 사용자도 들어갈 수 있는 문제 해결
	- accessToken 이 없을시 ( token 유무 검사 ) 
	- 위증된 Token 으로 리다이렉팅 시 ( use/profile/me 요청으로 intercept에서 걸리도록 ) 
	- 잠깐이나마 화면이 렌더링 되는 문제 ( 렌더링 순서가 component 생성 후에 hook 이기 때문 )  

> 접속한 사용자가 accessToken 을 삭제할시 intercept에서 login페이지로 리다이렉트가 안되는 문제

> 기존 token 만료 로직 수정



### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 잘못된 로직이 있을까요. 검토 부탁드립니다.
> 그리고 임의로 토큰에 accessToken 만들어서 리다이렉팅시에는 use/profile/me 요청을 보내서 axios 인터셉터에서 잡히도록 만들었는데 (token 검사) 이게 옳바른지는 모르겠습니다. (새로 아무 동작안하는 api요청을 만들어야하나.. 그렇다고 아무 반환 값없으면 상관없지 않나.. 생각이들어서요)